### PR TITLE
Take piped args into account in the PartialAppAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.5] - 2023-10-17
+
+### Fixed
+* Partial application analyzer takes piped arguments into account.
+
 ## [0.1.4] - 2023-10-16
 
 ### Changed

--- a/src/FSharp.Analyzers/PartialAppAnalyzer.fs
+++ b/src/FSharp.Analyzers/PartialAppAnalyzer.fs
@@ -9,7 +9,15 @@ open Microsoft.FSharp.Core
 [<Literal>]
 let Code = "GRA-PARTAPP-001"
 
-type Handler = string * FSharp.Compiler.Text.range * int -> unit
+type AppHandler = string * FSharp.Compiler.Text.range * int -> unit
+
+type PipeHandler = FSharp.Compiler.Text.range * int -> unit
+
+type Handlers =
+    {
+        AppHandler : AppHandler
+        PipeHandler : PipeHandler
+    }
 
 let collectExprFromMatchClauses (clauses : SynMatchClause list) =
     clauses
@@ -24,240 +32,288 @@ let collectExprFromMatchClauses (clauses : SynMatchClause list) =
     )
     |> List.concat
 
-let rec visitApp (handler : Handler) (depth : int) (expr : SynExpr) =
+let rec (|AppOfIdent|_|) (expr : SynExpr) =
+    match expr with
+    | SynExpr.App (funcExpr = SynExpr.Ident ident) -> Some ident
+    | SynExpr.App (funcExpr = SynExpr.App _ as a) ->
+        match a with
+        | AppOfIdent i -> Some i
+        | _ -> None
+    | _ -> None
+
+let rec (|AppOfLongIdent|_|) (expr : SynExpr) =
+    match expr with
+    | SynExpr.App (funcExpr = SynExpr.LongIdent (longDotId = ident)) -> Some ident
+    | SynExpr.App (funcExpr = SynExpr.App _ as a) ->
+        match a with
+        | AppOfLongIdent i -> Some i
+        | _ -> None
+    | _ -> None
+
+let collectPipedArgs (pipeHandler : PipeHandler) (funcExpr : SynExpr) (argExpr : SynExpr) =
+    match funcExpr with
+    | SynExpr.App (funcExpr = SynExpr.LongIdent (longDotId = longDotId) ; argExpr = argExpr2) ->
+        longDotId.LongIdent
+        |> Seq.tryHead
+        |> Option.iter (fun i ->
+            let pipedArgs, target =
+                match i.idText with
+                | "op_PipeRight" -> 1, Some argExpr
+                | "op_PipeRight2" -> 2, Some argExpr
+                | "op_PipeRight3" -> 3, Some argExpr
+                // not needed for op_PipeLeft
+                | "op_PipeLeft2" -> 2, Some argExpr2
+                | "op_PipeLeft3" -> 3, Some argExpr2
+                | _ -> 0, None
+
+            if pipedArgs > 0 then
+                target
+                |> Option.iter (
+                    function
+                    | AppOfIdent i -> pipeHandler (i.idRange, pipedArgs)
+                    | AppOfLongIdent i -> pipeHandler (i.Range, pipedArgs)
+                    | _ -> ()
+                )
+        )
+    | _ -> ()
+
+let rec visitApp (handlers : Handlers) (depth : int) (expr : SynExpr) =
     match expr with
     | SynExpr.App (funcExpr = SynExpr.Paren (expr = expr) ; argExpr = argExpr) ->
-        visitApp handler depth expr
-        visitExpr handler argExpr
-    | SynExpr.App (funcExpr = SynExpr.Ident i) -> handler (i.idText, i.idRange, 1 + depth)
+        visitApp handlers depth expr
+        visitExpr handlers argExpr
+    | SynExpr.App (funcExpr = SynExpr.Ident i) -> handlers.AppHandler (i.idText, i.idRange, 1 + depth)
     | SynExpr.App (funcExpr = SynExpr.LongIdent (longDotId = longDotId) ; argExpr = argExpr) ->
         longDotId.IdentsWithTrivia
         |> Seq.tryLast
-        |> Option.iter (fun (SynIdent.SynIdent (ident = ident)) -> handler (ident.idText, longDotId.Range, 1 + depth))
+        |> Option.iter (fun (SynIdent.SynIdent (ident = ident)) ->
+            handlers.AppHandler (ident.idText, longDotId.Range, 1 + depth)
+        )
 
-        visitApp handler depth argExpr
+        visitApp handlers depth argExpr
     | SynExpr.App (funcExpr = SynExpr.App _ as funcExpr ; argExpr = argExpr) ->
-        visitApp handler (1 + depth) funcExpr
-        visitApp handler depth argExpr
-    | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = SynExpr.Ident i)) -> handler (i.idText, i.idRange, 1 + depth)
+        collectPipedArgs handlers.PipeHandler funcExpr argExpr
+        visitApp handlers (1 + depth) funcExpr
+        visitApp handlers depth argExpr
+    | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = SynExpr.Ident i)) ->
+        handlers.AppHandler (i.idText, i.idRange, 1 + depth)
     | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = SynExpr.LongIdent (longDotId = longDotId))) ->
         longDotId.IdentsWithTrivia
         |> Seq.tryLast
-        |> Option.iter (fun (SynIdent.SynIdent (ident = ident)) -> handler (ident.idText, longDotId.Range, 1 + depth))
+        |> Option.iter (fun (SynIdent.SynIdent (ident = ident)) ->
+            handlers.AppHandler (ident.idText, longDotId.Range, 1 + depth)
+        )
     | SynExpr.IfThenElse (ifExpr = ifExpr ; thenExpr = thenExpr ; elseExpr = elseExpr) ->
-        visitApp handler depth ifExpr
-        visitApp handler depth thenExpr
-        Option.iter (visitApp handler depth) elseExpr
+        visitApp handlers depth ifExpr
+        visitApp handlers depth thenExpr
+        Option.iter (visitApp handlers depth) elseExpr
     | SynExpr.Match (expr = expr ; clauses = clauses) ->
         let matchExprs = collectExprFromMatchClauses clauses
-        visitApp handler depth expr
-        List.iter (visitApp handler depth) matchExprs
+        visitApp handlers depth expr
+        List.iter (visitApp handlers depth) matchExprs
     | SynExpr.MatchLambda (matchClauses = matchClauses) ->
         let matchExprs = collectExprFromMatchClauses matchClauses
-        List.iter (visitApp handler depth) matchExprs
+        List.iter (visitApp handlers depth) matchExprs
     | SynExpr.App (funcExpr = SynExpr.DotGet _) -> ()
     | SynExpr.App (funcExpr = SynExpr.DotIndexedGet _) -> ()
     | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = SynExpr.DotIndexedGet _)) -> ()
     | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = SynExpr.DotGet _)) -> ()
     | SynExpr.Const _
     | SynExpr.LongIdent _ -> ()
-
-    | _ ->
-        // printfn $"visitApp: not supported yet {expr}"
-        ()
-
-and visitMatchClause (handler : Handler) (SynMatchClause (resultExpr = resultExpr ; whenExpr = whenExpr)) =
-    visitExpr handler resultExpr
-    Option.iter (visitExpr handler) whenExpr
-
-and visitRecordField (handler : Handler) (SynExprRecordField (expr = expr)) = Option.iter (visitExpr handler) expr
-
-and visitAndBang (handler : Handler) (SynExprAndBang (body = body)) = visitExpr handler body
-
-and visitInterpolatedStringParts (handler : Handler) (part : SynInterpolatedStringPart) =
-    match part with
-    | SynInterpolatedStringPart.FillExpr (fillExpr = fillExpr) -> visitExpr handler fillExpr
     | _ -> ()
 
-and visitExpr (handler : Handler) (expr : SynExpr) =
+and visitMatchClause (handlers : Handlers) (SynMatchClause (resultExpr = resultExpr ; whenExpr = whenExpr)) =
+    visitExpr handlers resultExpr
+    Option.iter (visitExpr handlers) whenExpr
+
+and visitRecordField (handlers : Handlers) (SynExprRecordField (expr = expr)) = Option.iter (visitExpr handlers) expr
+
+and visitAndBang (handlers : Handlers) (SynExprAndBang (body = body)) = visitExpr handlers body
+
+and visitInterpolatedStringParts (handlers : Handlers) (part : SynInterpolatedStringPart) =
+    match part with
+    | SynInterpolatedStringPart.FillExpr (fillExpr = fillExpr) -> visitExpr handlers fillExpr
+    | _ -> ()
+
+and visitExpr (handlers : Handlers) (expr : SynExpr) =
     match expr with
-    | SynExpr.App _ as e -> visitApp handler 0 e
-    | SynExpr.Lambda (body = body) -> visitExpr handler body
+    | SynExpr.App _ as e -> visitApp handlers 0 e
+    | SynExpr.Lambda (body = body) -> visitExpr handlers body
     | SynExpr.LetOrUse (bindings = bindings ; body = body) ->
-        List.iter (visitBinding handler) bindings
-        visitExpr handler body
-    | SynExpr.Do (expr = expr) -> visitExpr handler expr
+        List.iter (visitBinding handlers) bindings
+        visitExpr handlers body
+    | SynExpr.Do (expr = expr) -> visitExpr handlers expr
     | SynExpr.Sequential (expr1 = expr1 ; expr2 = expr2) ->
-        visitExpr handler expr1
-        visitExpr handler expr2
-    | SynExpr.Typed (expr = expr) -> visitExpr handler expr
+        visitExpr handlers expr1
+        visitExpr handlers expr2
+    | SynExpr.Typed (expr = expr) -> visitExpr handlers expr
     | SynExpr.Match (expr = expr ; clauses = clauses) ->
-        visitExpr handler expr
-        clauses |> List.iter (visitMatchClause handler)
-    | SynExpr.Assert (expr = expr) -> visitExpr handler expr
-    | SynExpr.Downcast (expr = expr) -> visitExpr handler expr
+        visitExpr handlers expr
+        clauses |> List.iter (visitMatchClause handlers)
+    | SynExpr.Assert (expr = expr) -> visitExpr handlers expr
+    | SynExpr.Downcast (expr = expr) -> visitExpr handlers expr
     | SynExpr.Dynamic (funcExpr = funcExpr ; argExpr = argExpr) ->
-        visitExpr handler funcExpr
-        visitExpr handler argExpr
-    | SynExpr.Fixed (expr = expr) -> visitExpr handler expr
+        visitExpr handlers funcExpr
+        visitExpr handlers argExpr
+    | SynExpr.Fixed (expr = expr) -> visitExpr handlers expr
     | SynExpr.For (identBody = identBody ; toBody = synExpr ; doBody = doBody) ->
-        visitExpr handler identBody
-        visitExpr handler synExpr
-        visitExpr handler doBody
-    | SynExpr.Lazy (expr = expr) -> visitExpr handler expr
-    | SynExpr.New (expr = expr) -> visitExpr handler expr
-    | SynExpr.Paren (expr = expr) -> visitExpr handler expr
+        visitExpr handlers identBody
+        visitExpr handlers synExpr
+        visitExpr handlers doBody
+    | SynExpr.Lazy (expr = expr) -> visitExpr handlers expr
+    | SynExpr.New (expr = expr) -> visitExpr handlers expr
+    | SynExpr.Paren (expr = expr) -> visitExpr handlers expr
     | SynExpr.Quote (operator = operator ; quotedExpr = quotedExpr) ->
-        visitExpr handler operator
-        visitExpr handler quotedExpr
+        visitExpr handlers operator
+        visitExpr handlers quotedExpr
     | SynExpr.Record (baseInfo = baseInfo ; copyInfo = copyInfo ; recordFields = recordFields) ->
         match baseInfo with
-        | Some (_, expr, _, _, _) -> visitExpr handler expr
+        | Some (_, expr, _, _, _) -> visitExpr handlers expr
         | None -> ()
 
         match copyInfo with
-        | Some (expr, _) -> visitExpr handler expr
+        | Some (expr, _) -> visitExpr handlers expr
         | None -> ()
 
-        recordFields |> List.iter (visitRecordField handler)
+        recordFields |> List.iter (visitRecordField handlers)
     | SynExpr.Set (targetExpr = targetExpr ; rhsExpr = rhsExpr) ->
-        visitExpr handler targetExpr
-        visitExpr handler rhsExpr
-    | SynExpr.Tuple (exprs = exprs) -> List.iter (visitExpr handler) exprs
-    | SynExpr.Upcast (expr = expr) -> visitExpr handler expr
+        visitExpr handlers targetExpr
+        visitExpr handlers rhsExpr
+    | SynExpr.Tuple (exprs = exprs) -> List.iter (visitExpr handlers) exprs
+    | SynExpr.Upcast (expr = expr) -> visitExpr handlers expr
     | SynExpr.While (whileExpr = whileExpr ; doExpr = doExpr) ->
-        visitExpr handler whileExpr
-        visitExpr handler doExpr
-    | SynExpr.AddressOf (expr = expr) -> visitExpr handler expr
+        visitExpr handlers whileExpr
+        visitExpr handlers doExpr
+    | SynExpr.AddressOf (expr = expr) -> visitExpr handlers expr
     | SynExpr.AnonRecd (copyInfo = copyInfo ; recordFields = recordFields) ->
         match copyInfo with
-        | Some (expr, _) -> visitExpr handler expr
+        | Some (expr, _) -> visitExpr handlers expr
         | None -> ()
 
-        recordFields |> List.iter (fun (_, _, expr) -> visitExpr handler expr)
-    | SynExpr.ComputationExpr (expr = expr) -> visitExpr handler expr
-    | SynExpr.DebugPoint (innerExpr = innerExpr) -> visitExpr handler innerExpr
-    | SynExpr.DoBang (expr = expr) -> visitExpr handler expr
-    | SynExpr.DotGet (expr = expr) -> visitExpr handler expr
+        recordFields |> List.iter (fun (_, _, expr) -> visitExpr handlers expr)
+    | SynExpr.ComputationExpr (expr = expr) -> visitExpr handlers expr
+    | SynExpr.DebugPoint (innerExpr = innerExpr) -> visitExpr handlers innerExpr
+    | SynExpr.DoBang (expr = expr) -> visitExpr handlers expr
+    | SynExpr.DotGet (expr = expr) -> visitExpr handlers expr
     | SynExpr.DotSet (targetExpr = targetExpr ; rhsExpr = rhsExpr) ->
-        visitExpr handler targetExpr
-        visitExpr handler rhsExpr
+        visitExpr handlers targetExpr
+        visitExpr handlers rhsExpr
     | SynExpr.ForEach (enumExpr = enumExpr ; bodyExpr = bodyExpr) ->
-        visitExpr handler enumExpr
-        visitExpr handler bodyExpr
-    | SynExpr.ArrayOrList (exprs = exprs) -> List.iter (visitExpr handler) exprs
+        visitExpr handlers enumExpr
+        visitExpr handlers bodyExpr
+    | SynExpr.ArrayOrList (exprs = exprs) -> List.iter (visitExpr handlers) exprs
     | SynExpr.ObjExpr (argOptions = argOptions ; bindings = bindings ; members = members ; extraImpls = extraImpls) ->
         match argOptions with
-        | Some (expr, _) -> visitExpr handler expr
+        | Some (expr, _) -> visitExpr handlers expr
         | None -> ()
 
-        List.iter (visitBinding handler) bindings
-        List.iter (visitMemberDefn handler) members
-        List.iter (visitInterfaceImpl handler) extraImpls
-    | SynExpr.ArrayOrListComputed (expr = expr) -> visitExpr handler expr
+        List.iter (visitBinding handlers) bindings
+        List.iter (visitMemberDefn handlers) members
+        List.iter (visitInterfaceImpl handlers) extraImpls
+    | SynExpr.ArrayOrListComputed (expr = expr) -> visitExpr handlers expr
     | SynExpr.IndexRange (expr1 = expr1 ; expr2 = expr2) ->
-        Option.iter (visitExpr handler) expr1
-        Option.iter (visitExpr handler) expr2
-    | SynExpr.IndexFromEnd (expr = expr) -> visitExpr handler expr
-    | SynExpr.MatchLambda (matchClauses = matchClauses) -> List.iter (visitMatchClause handler) matchClauses
-    | SynExpr.TypeApp (expr = expr) -> visitExpr handler expr
+        Option.iter (visitExpr handlers) expr1
+        Option.iter (visitExpr handlers) expr2
+    | SynExpr.IndexFromEnd (expr = expr) -> visitExpr handlers expr
+    | SynExpr.MatchLambda (matchClauses = matchClauses) -> List.iter (visitMatchClause handlers) matchClauses
+    | SynExpr.TypeApp (expr = expr) -> visitExpr handlers expr
     | SynExpr.TryWith (tryExpr = tryExpr ; withCases = withCases) ->
-        visitExpr handler tryExpr
-        List.iter (visitMatchClause handler) withCases
+        visitExpr handlers tryExpr
+        List.iter (visitMatchClause handlers) withCases
     | SynExpr.TryFinally (tryExpr = tryExpr ; finallyExpr = finallyExpr) ->
-        visitExpr handler tryExpr
-        visitExpr handler finallyExpr
+        visitExpr handlers tryExpr
+        visitExpr handlers finallyExpr
     | SynExpr.IfThenElse (ifExpr = ifExpr ; thenExpr = thenExpr ; elseExpr = elseExpr) ->
-        visitExpr handler ifExpr
-        visitExpr handler thenExpr
-        Option.iter (visitExpr handler) elseExpr
-    | SynExpr.LongIdentSet (expr = expr) -> visitExpr handler expr
+        visitExpr handlers ifExpr
+        visitExpr handlers thenExpr
+        Option.iter (visitExpr handlers) elseExpr
+    | SynExpr.LongIdentSet (expr = expr) -> visitExpr handlers expr
     | SynExpr.DotIndexedGet (objectExpr = objectExpr ; indexArgs = indexArgs) ->
-        visitExpr handler objectExpr
-        visitExpr handler indexArgs
+        visitExpr handlers objectExpr
+        visitExpr handlers indexArgs
     | SynExpr.DotIndexedSet (objectExpr = objectExpr ; indexArgs = indexArgs ; valueExpr = valueExpr) ->
-        visitExpr handler objectExpr
-        visitExpr handler indexArgs
-        visitExpr handler valueExpr
+        visitExpr handlers objectExpr
+        visitExpr handlers indexArgs
+        visitExpr handlers valueExpr
     | SynExpr.NamedIndexedPropertySet (expr1 = expr1 ; expr2 = expr2) ->
-        visitExpr handler expr1
-        visitExpr handler expr2
+        visitExpr handlers expr1
+        visitExpr handlers expr2
     | SynExpr.DotNamedIndexedPropertySet (targetExpr = targetExpr ; argExpr = argExpr ; rhsExpr = rhsExpr) ->
-        visitExpr handler targetExpr
-        visitExpr handler argExpr
-        visitExpr handler rhsExpr
-    | SynExpr.TypeTest (expr = expr) -> visitExpr handler expr
-    | SynExpr.InferredUpcast (expr = expr) -> visitExpr handler expr
-    | SynExpr.InferredDowncast (expr = expr) -> visitExpr handler expr
-    | SynExpr.TraitCall (argExpr = argExpr) -> visitExpr handler argExpr
+        visitExpr handlers targetExpr
+        visitExpr handlers argExpr
+        visitExpr handlers rhsExpr
+    | SynExpr.TypeTest (expr = expr) -> visitExpr handlers expr
+    | SynExpr.InferredUpcast (expr = expr) -> visitExpr handlers expr
+    | SynExpr.InferredDowncast (expr = expr) -> visitExpr handlers expr
+    | SynExpr.TraitCall (argExpr = argExpr) -> visitExpr handlers argExpr
     | SynExpr.JoinIn (lhsExpr = lhsExpr ; rhsExpr = rhsExpr) ->
-        visitExpr handler lhsExpr
-        visitExpr handler rhsExpr
+        visitExpr handlers lhsExpr
+        visitExpr handlers rhsExpr
     | SynExpr.SequentialOrImplicitYield (expr1 = expr1 ; expr2 = expr2 ; ifNotStmt = ifNotStmt) ->
-        visitExpr handler expr1
-        visitExpr handler expr2
-        visitExpr handler ifNotStmt
-    | SynExpr.YieldOrReturn (expr = expr) -> visitExpr handler expr
-    | SynExpr.YieldOrReturnFrom (expr = expr) -> visitExpr handler expr
+        visitExpr handlers expr1
+        visitExpr handlers expr2
+        visitExpr handlers ifNotStmt
+    | SynExpr.YieldOrReturn (expr = expr) -> visitExpr handlers expr
+    | SynExpr.YieldOrReturnFrom (expr = expr) -> visitExpr handlers expr
     | SynExpr.LetOrUseBang (rhs = rhs ; andBangs = andBangs ; body = body) ->
-        visitExpr handler rhs
-        List.iter (visitAndBang handler) andBangs
-        visitExpr handler body
+        visitExpr handlers rhs
+        List.iter (visitAndBang handlers) andBangs
+        visitExpr handlers body
     | SynExpr.MatchBang (expr = expr ; clauses = clauses) ->
-        visitExpr handler expr
-        List.iter (visitMatchClause handler) clauses
-    | SynExpr.LibraryOnlyILAssembly (args = args) -> List.iter (visitExpr handler) args
+        visitExpr handlers expr
+        List.iter (visitMatchClause handlers) clauses
+    | SynExpr.LibraryOnlyILAssembly (args = args) -> List.iter (visitExpr handlers) args
     | SynExpr.LibraryOnlyStaticOptimization (expr = expr ; optimizedExpr = optimizedExpr) ->
-        visitExpr handler expr
-        visitExpr handler optimizedExpr
-    | SynExpr.LibraryOnlyUnionCaseFieldGet (expr = expr) -> visitExpr handler expr
+        visitExpr handlers expr
+        visitExpr handlers optimizedExpr
+    | SynExpr.LibraryOnlyUnionCaseFieldGet (expr = expr) -> visitExpr handlers expr
     | SynExpr.LibraryOnlyUnionCaseFieldSet (expr = expr ; rhsExpr = rhsExpr) ->
-        visitExpr handler expr
-        visitExpr handler rhsExpr
-    | SynExpr.InterpolatedString (contents = contents) -> List.iter (visitInterpolatedStringParts handler) contents
+        visitExpr handlers expr
+        visitExpr handlers rhsExpr
+    | SynExpr.InterpolatedString (contents = contents) -> List.iter (visitInterpolatedStringParts handlers) contents
     | _ -> ()
 
-and visitBinding (handler : Handler) (SynBinding (expr = expr)) = visitExpr handler expr
+and visitBinding (handlers : Handlers) (SynBinding (expr = expr)) = visitExpr handlers expr
 
-and visitInterfaceImpl (handler : Handler) (SynInterfaceImpl (bindings = bindings ; members = members)) =
-    List.iter (visitBinding handler) bindings
-    List.iter (visitMemberDefn handler) members
+and visitInterfaceImpl (handlers : Handlers) (SynInterfaceImpl (bindings = bindings ; members = members)) =
+    List.iter (visitBinding handlers) bindings
+    List.iter (visitMemberDefn handlers) members
 
-and visitMemberDefn (handler : Handler) (memberDefn : SynMemberDefn) =
+and visitMemberDefn (handlers : Handlers) (memberDefn : SynMemberDefn) =
     match memberDefn with
-    | SynMemberDefn.LetBindings (bindings = bindings) -> List.iter (visitBinding handler) bindings
-    | SynMemberDefn.Member (memberDefn = memberDefn) -> visitBinding handler memberDefn
+    | SynMemberDefn.LetBindings (bindings = bindings) -> List.iter (visitBinding handlers) bindings
+    | SynMemberDefn.Member (memberDefn = memberDefn) -> visitBinding handlers memberDefn
     | SynMemberDefn.GetSetMember (memberDefnForGet = memberDefnForGet ; memberDefnForSet = memberDefnForSet) ->
-        Option.iter (visitBinding handler) memberDefnForGet
-        Option.iter (visitBinding handler) memberDefnForSet
-    | SynMemberDefn.Interface (members = members) -> Option.iter (List.iter (visitMemberDefn handler)) members
-    | SynMemberDefn.NestedType (typeDefn = typeDefn) -> visitTypeDefn handler typeDefn
-    | SynMemberDefn.AutoProperty (synExpr = synExpr) -> visitExpr handler synExpr
+        Option.iter (visitBinding handlers) memberDefnForGet
+        Option.iter (visitBinding handlers) memberDefnForSet
+    | SynMemberDefn.Interface (members = members) -> Option.iter (List.iter (visitMemberDefn handlers)) members
+    | SynMemberDefn.NestedType (typeDefn = typeDefn) -> visitTypeDefn handlers typeDefn
+    | SynMemberDefn.AutoProperty (synExpr = synExpr) -> visitExpr handlers synExpr
     | _ -> ()
 
-and visitTypeDefn (handler : Handler) (synTypeDefn : SynTypeDefn) =
+and visitTypeDefn (handlers : Handlers) (synTypeDefn : SynTypeDefn) =
     match synTypeDefn with
     | SynTypeDefn.SynTypeDefn (typeRepr = typeRepr ; members = members) ->
         match typeRepr with
-        | SynTypeDefnRepr.ObjectModel (members = members) -> List.iter (visitMemberDefn handler) members
-        | SynTypeDefnRepr.Simple _ -> List.iter (visitMemberDefn handler) members
+        | SynTypeDefnRepr.ObjectModel (members = members) -> List.iter (visitMemberDefn handlers) members
+        | SynTypeDefnRepr.Simple _ -> List.iter (visitMemberDefn handlers) members
         | _ -> ()
 
-and visitModuleDecl (handler : Handler) (decl : SynModuleDecl) =
+and visitModuleDecl (handlers : Handlers) (decl : SynModuleDecl) =
     match decl with
-    | SynModuleDecl.NestedModule (decls = decls) -> List.iter (visitModuleDecl handler) decls
-    | SynModuleDecl.Let (bindings = bindings) -> List.iter (visitBinding handler) bindings
-    | SynModuleDecl.Expr (expr = expr) -> visitExpr handler expr
-    | SynModuleDecl.Types (typeDefns = typeDefns) -> List.iter (visitTypeDefn handler) typeDefns
+    | SynModuleDecl.NestedModule (decls = decls) -> List.iter (visitModuleDecl handlers) decls
+    | SynModuleDecl.Let (bindings = bindings) -> List.iter (visitBinding handlers) bindings
+    | SynModuleDecl.Expr (expr = expr) -> visitExpr handlers expr
+    | SynModuleDecl.Types (typeDefns = typeDefns) -> List.iter (visitTypeDefn handlers) typeDefns
     | SynModuleDecl.Exception (exnDefn = SynExceptionDefn (members = members)) ->
-        List.iter (visitMemberDefn handler) members
+        List.iter (visitMemberDefn handlers) members
     | _ -> ()
 
-and visitModuleDecls (handler : Handler) (decls : SynModuleDecl list) =
-    List.iter (visitModuleDecl handler) decls
+and visitModuleDecls (handlers : Handlers) (decls : SynModuleDecl list) =
+    List.iter (visitModuleDecl handlers) decls
 
-and visitModuleOrNamespace (handler : Handler) (SynModuleOrNamespace (decls = decls) : SynModuleOrNamespace) =
-    visitModuleDecls handler decls
+and visitModuleOrNamespace (handlers : Handlers) (SynModuleOrNamespace (decls = decls) : SynModuleOrNamespace) =
+    visitModuleDecls handlers decls
 
 let tryGetParameterCount (symbolUses : FSharpSymbolUse seq) r =
     symbolUses
@@ -270,23 +326,41 @@ let tryGetParameterCount (symbolUses : FSharpSymbolUse seq) r =
     |> Option.flatten
 
 let analyze parseTree (checkFileResults : FSharpCheckFileResults) =
-    let state = ResizeArray<string * FSharp.Compiler.Text.range * int> ()
-    let handler : Handler = fun (ident, r, args) -> state.Add (ident, r, args)
+    let providedArgs = ResizeArray<string * FSharp.Compiler.Text.range * int> ()
+    let pipedArgs = ResizeArray<FSharp.Compiler.Text.range * int> ()
+
+    let appHandler : AppHandler =
+        fun (ident, r, args) -> providedArgs.Add (ident, r, args)
+
+    let pipeHandler : PipeHandler = fun (r, c) -> pipedArgs.Add (r, c)
+
+    let handlers =
+        {
+            AppHandler = appHandler
+            PipeHandler = pipeHandler
+        }
+
     let symbolUses = checkFileResults.GetAllUsesOfAllSymbolsInFile ()
 
     match parseTree with
     | ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput (contents = contents)) ->
-        contents |> List.iter (visitModuleOrNamespace handler)
+        contents |> List.iter (visitModuleOrNamespace handlers)
     | _ -> ()
 
     let msgs =
         seq {
-            for _, range, providedArgsCount in state do
+            for _, range, providedArgsCount in providedArgs do
                 let parameterCount = tryGetParameterCount symbolUses range
 
                 match parameterCount with
                 | Some paramsCount ->
-                    if providedArgsCount < paramsCount then // use LESS, not NOT EQUAL because of CEs, printf, etc. take more than paramsCount
+                    let piped =
+                        pipedArgs
+                        |> Seq.tryFind (fun (r, _) -> r = range)
+                        |> Option.map snd
+                        |> Option.defaultValue 0
+
+                    if providedArgsCount + piped < paramsCount then // use LESS, not NOT EQUAL because of CEs, printf, etc. take more than paramsCount
                         let msg =
                             {
                                 Type = "Partial Application Analyzer"

--- a/tests/FSharp.Analyzers.Tests/PartialAppAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/PartialAppAnalyzerTests.fs
@@ -47,3 +47,22 @@ module PartialAppAnalyzerTests =
 
             do! assertExpected fileName messages
         }
+
+    type NegativeTestCases() =
+
+        interface IEnumerable with
+            member _.GetEnumerator () : IEnumerator =
+                constructTestCaseEnumerator [| "partialapp" ; "negative" |]
+
+    [<TestCaseSource(typeof<NegativeTestCases>)>]
+    let NegativeTests (fileName : string) =
+        task {
+            let fileName = Path.Combine (dataFolder, fileName)
+
+            let! messages =
+                File.ReadAllText fileName
+                |> getContext projectOptions
+                |> PartialAppAnalyzer.partialAppCliAnalyzer
+
+            Assert.IsEmpty messages
+        }

--- a/tests/data/partialapp/negative/No warning for left piped args.fs
+++ b/tests/data/partialapp/negative/No warning for left piped args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b = a + b
+
+myFunc 10 <| 20

--- a/tests/data/partialapp/negative/No warning for left piped2 args.fs
+++ b/tests/data/partialapp/negative/No warning for left piped2 args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b c = a + b + c
+
+myFunc 10 <|| (20, 30)

--- a/tests/data/partialapp/negative/No warning for left piped3 args.fs
+++ b/tests/data/partialapp/negative/No warning for left piped3 args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b c d = a + b + c + d
+
+myFunc 10 <||| (20, 30, 40)

--- a/tests/data/partialapp/negative/No warning for right piped args to fold.fs
+++ b/tests/data/partialapp/negative/No warning for right piped args to fold.fs
@@ -1,0 +1,3 @@
+module M
+
+[1;2;3] |> List.fold (fun a b -> a + b) 100

--- a/tests/data/partialapp/negative/No warning for right piped args.fs
+++ b/tests/data/partialapp/negative/No warning for right piped args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b = a + b
+
+20 |> myFunc 10

--- a/tests/data/partialapp/negative/No warning for right piped args2.fs
+++ b/tests/data/partialapp/negative/No warning for right piped args2.fs
@@ -3,5 +3,4 @@ module M
 let f x = 3 + x
 let myFunc a b c d = a + b + c + d
 
-// Seq.head [20; 0] |> myFunc 10 20
 30 |> myFunc 10 20 21

--- a/tests/data/partialapp/negative/No warning for right piped args2.fs
+++ b/tests/data/partialapp/negative/No warning for right piped args2.fs
@@ -1,0 +1,7 @@
+module M
+
+let f x = 3 + x
+let myFunc a b c d = a + b + c + d
+
+// Seq.head [20; 0] |> myFunc 10 20
+30 |> myFunc 10 20 21

--- a/tests/data/partialapp/negative/No warning for right piped2 args.fs
+++ b/tests/data/partialapp/negative/No warning for right piped2 args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b c = a + b + c
+
+(20, 30) ||> myFunc 10

--- a/tests/data/partialapp/negative/No warning for right piped3 args.fs
+++ b/tests/data/partialapp/negative/No warning for right piped3 args.fs
@@ -1,0 +1,5 @@
+module M
+
+let myFunc a b c d = a + b + c + d
+
+(20, 30, 40) |||> myFunc 10


### PR DESCRIPTION
Although the targets of pipes are mostly partially applied functions, we shouldn't warn about them as such.
Piping is pretty much an F# idiom to provide args to functions.