### PR TITLE
Add additional MSBuild properties to align with Roslyn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.1.6] - 2023-12-26
 
 ### Changed
-* Add more MSBuild properties to align with Roslyn.
+* Add more MSBuild properties to align with Roslyn. [#25](https://github.com/G-Research/fsharp-analyzers/pull/25)
+* Update FSharp.Analyzers.SDK to `0.17.0`. [#25](https://github.com/G-Research/fsharp-analyzers/pull/25)
 
 ## [0.1.5] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.6] - 2023-12-26
+
+### Changed
+* Add more MSBuild properties to align with Roslyn.
+
 ## [0.1.5] - 2023-10-17
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
             F# analyzers used within G-Research.
         </Description>
         <Copyright>Copyright G-Research © $([System.DateTime]::UtcNow.Year)</Copyright>
-        <PackageTags>F# fsharp analyzers</PackageTags>
+        <PackageTags>F#, fsharp, analyzers</PackageTags>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <DebugType>embedded</DebugType>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- locking the version of F# Core as FCS does this anyway and in practise all will be using the same version -->
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.16.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="0.16.0" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.17.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="0.17.0" />
     <PackageVersion Include="FSharp.Core" Version="[7.0.400]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.7.400]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />

--- a/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
+++ b/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
@@ -6,6 +6,10 @@
         <IsPackable>true</IsPackable>
         <AssemblyName>G-Research.FSharp.Analyzers</AssemblyName>
         <Tailcalls>true</Tailcalls>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,4 +28,9 @@
         <PackageReference Include="FSharp.Compiler.Service"/>
     </ItemGroup>
 
+    <Target Name="_AddAnalyzersToOutput">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/fs" />
+        </ItemGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
This aligns better with what Rosyln does today.
I found these properties from https://github.com/dotnet/samples/blob/main/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Package/MakeConst.Package.csproj and will document the Ionide SDK later today.