### PR TITLE
Update sdk and add analyzer for Seq functions that have an equivalent in the collection modules

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- locking the version of F# Core as FCS does this anyway and in practise all will be using the same version -->
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.18.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="0.18.0" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.19.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="0.19.0" />
     <PackageVersion Include="FSharp.Core" Version="[7.0.400]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.7.400]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />

--- a/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
+++ b/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
@@ -1,34 +1,35 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <IsPackable>true</IsPackable>
-        <AssemblyName>G-Research.FSharp.Analyzers</AssemblyName>
-        <Tailcalls>true</Tailcalls>
-        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-        <DevelopmentDependency>true</DevelopmentDependency>
-        <NoPackageAnalysis>true</NoPackageAnalysis>
-        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <AssemblyName>G-Research.FSharp.Analyzers</AssemblyName>
+    <Tailcalls>true</Tailcalls>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="StringAnalyzer.fsi" />
+    <Compile Include="StringAnalyzer.fs" />
+    <Compile Include="JsonSerializerOptionsAnalyzer.fs" />
+    <Compile Include="UnionCaseAnalyzer.fs" />
+    <Compile Include="PartialAppAnalyzer.fs" />
+    <Compile Include="VirtualCallAnalyzer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" />
+    <PackageReference Include="FSharp.Analyzers.SDK"/>
+    <PackageReference Include="FSharp.Compiler.Service"/>
+  </ItemGroup>
+
+  <Target Name="_AddAnalyzersToOutput">
     <ItemGroup>
-        <Compile Include="StringAnalyzer.fsi" />
-        <Compile Include="StringAnalyzer.fs" />
-        <Compile Include="JsonSerializerOptionsAnalyzer.fs" />
-        <Compile Include="UnionCaseAnalyzer.fs" />
-        <Compile Include="PartialAppAnalyzer.fs" />
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/fs" />
     </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Update="FSharp.Core" />
-        <PackageReference Include="FSharp.Analyzers.SDK"/>
-        <PackageReference Include="FSharp.Compiler.Service"/>
-    </ItemGroup>
-
-    <Target Name="_AddAnalyzersToOutput">
-        <ItemGroup>
-            <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/fs" />
-        </ItemGroup>
-    </Target>
+  </Target>
 </Project>

--- a/src/FSharp.Analyzers/JsonSerializerOptionsAnalyzer.fs
+++ b/src/FSharp.Analyzers/JsonSerializerOptionsAnalyzer.fs
@@ -33,7 +33,14 @@ let jsonSerializerOptionsAnalyzer : Analyzer<CliContext> =
 
             let walker =
                 { new TypedTreeCollectorBase() with
-                    override _.WalkCall (range : range) (m : FSharpMemberOrFunctionOrValue) (args : FSharpExpr list) =
+                    override _.WalkCall
+                        _
+                        (m : FSharpMemberOrFunctionOrValue)
+                        _
+                        _
+                        (args : FSharpExpr list)
+                        (range : range)
+                        =
                         let name = String.Join (".", m.DeclaringEntity.Value.FullName, m.DisplayName)
                         let assemblyName = "System.Text.Json"
 
@@ -59,7 +66,7 @@ let jsonSerializerOptionsAnalyzer : Analyzer<CliContext> =
 
             match ctx.TypedTree with
             | None -> ()
-            | Some typedTree -> typedTree.Declarations |> List.iter (walkTast walker)
+            | Some typedTree -> walkTast walker typedTree
 
             return
                 state

--- a/src/FSharp.Analyzers/StringAnalyzer.fs
+++ b/src/FSharp.Analyzers/StringAnalyzer.fs
@@ -38,7 +38,7 @@ let invalidStringFunctionUseAnalyzer
 
     let walker =
         { new TypedTreeCollectorBase() with
-            override _.WalkCall (m : range) (mfv : FSharpMemberOrFunctionOrValue) (args : FSharpExpr list) =
+            override _.WalkCall _ (mfv : FSharpMemberOrFunctionOrValue) _ _ (args : FSharpExpr list) (m : range) =
                 if
                     (mfv.Assembly.SimpleName = "System.Runtime"
                      || mfv.Assembly.SimpleName = "netstandard")
@@ -48,8 +48,7 @@ let invalidStringFunctionUseAnalyzer
                     invocations.Add m
         }
 
-    for decl in typedTree.Declarations do
-        walkTast walker decl
+    walkTast walker typedTree
 
     invocations
     |> Seq.map (fun mFunctionName ->

--- a/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
+++ b/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
@@ -9,12 +9,6 @@ open FSharp.Compiler.Text
 [<Literal>]
 let Code = "GRA-VIRTUALCALL-001"
 
-let f () =
-    let mySet = [ 1..10 ] |> Set.ofSeq
-    let b1 = Seq.max mySet // should warn
-    let b2 = Set.maxElement mySet // should not warn
-    b1, b2
-
 let (|CoerceToSeq|_|) (includeFromSet : bool) (expr : FSharpExpr) =
     match expr with
     | Coerce (t, e) when
@@ -140,7 +134,14 @@ let virtualCallAnalyzer : Analyzer<CliContext> =
 
             let walker =
                 { new TypedTreeCollectorBase() with
-                    override _.WalkCall (range : range) (mfv : FSharpMemberOrFunctionOrValue) (args : FSharpExpr list) =
+                    override _.WalkCall
+                        _
+                        (mfv : FSharpMemberOrFunctionOrValue)
+                        _
+                        _
+                        (args : FSharpExpr list)
+                        (range : range)
+                        =
 
                         let inAllCollections =
                             seqFuncsWithEquivalentsInAllCollections |> Set.contains mfv.FullName
@@ -181,7 +182,7 @@ let virtualCallAnalyzer : Analyzer<CliContext> =
                 }
 
             match context.TypedTree with
-            | Some t -> t.Declarations |> List.iter (walkTast walker)
+            | Some t -> walkTast walker t
             | None -> ()
 
             return

--- a/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
+++ b/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
@@ -153,7 +153,7 @@ let virtualCallAnalyzer : Analyzer<CliContext> =
                         "Microsoft.FSharp.Collections.Seq.tryFindIndexBack"
                         "Microsoft.FSharp.Collections.Seq.tryItem"
                         "Microsoft.FSharp.Collections.Seq.tryPick"
-                        "Microsoft.FSharp.Collections.Seq.transpose" // ToDo special arg0 handling
+                        "Microsoft.FSharp.Collections.Seq.transpose"
                         "Microsoft.FSharp.Collections.Seq.truncate"
                         "Microsoft.FSharp.Collections.Seq.unfold"
                         "Microsoft.FSharp.Collections.Seq.windowed"
@@ -210,6 +210,11 @@ let virtualCallAnalyzer : Analyzer<CliContext> =
                                     | [ idx0 ; idx1 ] ->
                                         match args[idx0], args[idx1] with
                                         | CoerceToSeq inAllCollections m1, CoerceToSeq inAllCollections m2 when m1 = m2 ->
+                                            state.Add (mfv.DisplayName, m1, range)
+                                        | _ -> ()
+                                    | [ idx0; idx1; idx2 ] ->
+                                        match args[idx0], args[idx1], args[idx2] with
+                                        | CoerceToSeq inAllCollections m1, CoerceToSeq inAllCollections m2, CoerceToSeq inAllCollections m3 when m1 = m2 && m2 = m3 ->
                                             state.Add (mfv.DisplayName, m1, range)
                                         | _ -> ()
                                     | _ -> ()

--- a/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
+++ b/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
@@ -1,0 +1,238 @@
+module GR.FSharp.Analyzers.VirtualCallAnalyzer
+
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.TASTCollecting
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Symbols.FSharpExprPatterns
+open FSharp.Compiler.Text
+
+[<Literal>]
+let Code = "GRA-VIRTUALCALL-001"
+
+let f () =
+    let mySet = [ 1..10 ] |> Set.ofSeq
+    let b1 = Seq.max mySet // should warn
+    let b2 = Set.maxElement mySet // should not warn
+    b1, b2
+
+let (|CoerceToSeqFromArrayOrListOrSet|_|) (expr : FSharpExpr) =
+    match expr with
+    | Coerce (t, e) when
+        t.HasTypeDefinition
+        && t.TypeDefinition.LogicalName = "seq`1"
+        && e.Type.HasTypeDefinition
+        ->
+        match e.Type.TypeDefinition.LogicalName with
+        | "[]`1" -> Some "Array"
+        | "list`1" -> Some "List"
+        | "Set`1" -> Some "Set"
+        | _ -> None
+    | _ -> None
+
+let (|CoerceToSeqFromArrayOrList|_|) (expr : FSharpExpr) =
+    match expr with
+    | Coerce (t, e) when
+        t.HasTypeDefinition
+        && t.TypeDefinition.LogicalName = "seq`1"
+        && e.Type.HasTypeDefinition
+        ->
+        match e.Type.TypeDefinition.LogicalName with
+        | "[]`1" -> Some "Array"
+        | "list`1" -> Some "List"
+        | _ -> None
+    | _ -> None
+
+[<CliAnalyzer>]
+let virtualCallAnalyzer : Analyzer<CliContext> =
+    fun (context : CliContext) ->
+        async {
+            let state = ResizeArray<string * string * range> ()
+
+            let seqFuncsWithEquivalentsInAllCollectionsArg0 =
+                set
+                    [
+                        "Microsoft.FSharp.Collections.Seq.isEmpty"
+                        "Microsoft.FSharp.Collections.Seq.length" // ~ Set.count
+                        "Microsoft.FSharp.Collections.Seq.max" // ~ Set.maxElement
+                        "Microsoft.FSharp.Collections.Seq.min" // ~ Set.minElement
+                    ]
+
+            let seqFuncsWithEquivalentsInAllCollectionsArg1 =
+                set
+                    [
+                        "Microsoft.FSharp.Collections.Seq.contains"
+                        "Microsoft.FSharp.Collections.Seq.exists"
+                        "Microsoft.FSharp.Collections.Seq.filter"
+                        "Microsoft.FSharp.Collections.Seq.foldBack"
+                        "Microsoft.FSharp.Collections.Seq.forall"
+                        "Microsoft.FSharp.Collections.Seq.iter"
+                        "Microsoft.FSharp.Collections.Seq.map"
+                    ]
+
+            let seqFuncsWithEquivalentsInAllCollectionsArg2 =
+                set [ "Microsoft.FSharp.Collections.Seq.fold" ]
+
+            let seqFuncsWithEquivalentsInAllCollectionsArg1And2 =
+                set
+                    [
+                        "Microsoft.FSharp.Collections.Seq.except" // ~ Set.difference
+                    ]
+
+            let seqFuncsWithEquivalentsInArrayAndListArg0 =
+                set
+                    [
+                        "Microsoft.FSharp.Collections.Seq.average"
+                        "Microsoft.FSharp.Collections.Seq.distinct"
+                        "Microsoft.FSharp.Collections.Seq.head"
+                        "Microsoft.FSharp.Collections.Seq.tryHead"
+                        "Microsoft.FSharp.Collections.Seq.last"
+                        "Microsoft.FSharp.Collections.Seq.tryLast"
+                        "Microsoft.FSharp.Collections.Seq.exactlyOne"
+                        "Microsoft.FSharp.Collections.Seq.tryExactlyOne"
+                        "Microsoft.FSharp.Collections.Seq.indexed"
+                        "Microsoft.FSharp.Collections.Seq.pairwise"
+                        "Microsoft.FSharp.Collections.Seq.rev"
+                        "Microsoft.FSharp.Collections.Seq.sort"
+                        "Microsoft.FSharp.Collections.Seq.sortDescending"
+                        "Microsoft.FSharp.Collections.Seq.sum"
+                        "Microsoft.FSharp.Collections.Seq.tail"
+                    ]
+
+            let seqFuncsWithEquivalentsInArrayAndList =
+                set
+                    [
+                        "Microsoft.FSharp.Collections.Seq.append"
+                        "Microsoft.FSharp.Collections.Seq.averageBy"
+                        "Microsoft.FSharp.Collections.Seq.choose"
+                        "Microsoft.FSharp.Collections.Seq.chunkBySize"
+                        "Microsoft.FSharp.Collections.Seq.collect"
+                        "Microsoft.FSharp.Collections.Seq.compareWith"
+                        "Microsoft.FSharp.Collections.Seq.concat"
+                        "Microsoft.FSharp.Collections.Seq.countBy"
+                        "Microsoft.FSharp.Collections.Seq.distinctBy"
+                        "Microsoft.FSharp.Collections.Seq.splitInto"
+                        "Microsoft.FSharp.Collections.Seq.exists2"
+                        "Microsoft.FSharp.Collections.Seq.where"
+                        "Microsoft.FSharp.Collections.Seq.find"
+                        "Microsoft.FSharp.Collections.Seq.findBack"
+                        "Microsoft.FSharp.Collections.Seq.findIndex"
+                        "Microsoft.FSharp.Collections.Seq.findIndexBack"
+                        "Microsoft.FSharp.Collections.Seq.fold2"
+                        "Microsoft.FSharp.Collections.Seq.foldBack2"
+                        "Microsoft.FSharp.Collections.Seq.forall2"
+                        "Microsoft.FSharp.Collections.Seq.groupBy"
+                        "Microsoft.FSharp.Collections.Seq.item"
+                        "Microsoft.FSharp.Collections.Seq.iteri"
+                        "Microsoft.FSharp.Collections.Seq.iter2"
+                        "Microsoft.FSharp.Collections.Seq.iteri2"
+                        "Microsoft.FSharp.Collections.Seq.map2"
+                        "Microsoft.FSharp.Collections.Seq.mapFold"
+                        "Microsoft.FSharp.Collections.Seq.mapFoldBack"
+                        "Microsoft.FSharp.Collections.Seq.map3"
+                        "Microsoft.FSharp.Collections.Seq.mapi"
+                        "Microsoft.FSharp.Collections.Seq.mapi2"
+                        "Microsoft.FSharp.Collections.Seq.maxBy"
+                        "Microsoft.FSharp.Collections.Seq.minBy"
+                        "Microsoft.FSharp.Collections.Seq.permute"
+                        "Microsoft.FSharp.Collections.Seq.pick"
+                        "Microsoft.FSharp.Collections.Seq.reduce"
+                        "Microsoft.FSharp.Collections.Seq.replicate"
+                        "Microsoft.FSharp.Collections.Seq.reduceBack"
+                        "Microsoft.FSharp.Collections.Seq.scan"
+                        "Microsoft.FSharp.Collections.Seq.scanBack"
+                        "Microsoft.FSharp.Collections.Seq.skip"
+                        "Microsoft.FSharp.Collections.Seq.skipWhile"
+                        "Microsoft.FSharp.Collections.Seq.sortWith"
+                        "Microsoft.FSharp.Collections.Seq.sortBy"
+                        "Microsoft.FSharp.Collections.Seq.sortByDescending"
+                        "Microsoft.FSharp.Collections.Seq.sumBy"
+                        "Microsoft.FSharp.Collections.Seq.take"
+                        "Microsoft.FSharp.Collections.Seq.takeWhile"
+                        "Microsoft.FSharp.Collections.Seq.tryFind"
+                        "Microsoft.FSharp.Collections.Seq.tryFindBack"
+                        "Microsoft.FSharp.Collections.Seq.tryFindIndex"
+                        "Microsoft.FSharp.Collections.Seq.tryFindIndexBack"
+                        "Microsoft.FSharp.Collections.Seq.tryItem"
+                        "Microsoft.FSharp.Collections.Seq.tryPick"
+                        "Microsoft.FSharp.Collections.Seq.transpose" // ToDo special arg0 handling
+                        "Microsoft.FSharp.Collections.Seq.truncate"
+                        "Microsoft.FSharp.Collections.Seq.unfold"
+                        "Microsoft.FSharp.Collections.Seq.windowed"
+                        "Microsoft.FSharp.Collections.Seq.zip"
+                        "Microsoft.FSharp.Collections.Seq.zip3"
+                        "Microsoft.FSharp.Collections.Seq.removeAt"
+                        "Microsoft.FSharp.Collections.Seq.removeManyAt"
+                        "Microsoft.FSharp.Collections.Seq.updateAt"
+                        "Microsoft.FSharp.Collections.Seq.insertAt"
+                        "Microsoft.FSharp.Collections.Seq.insertManyAt"
+                        "Microsoft.FSharp.Collections.Seq.allPairs"
+                    ]
+
+            let walker =
+                { new TypedTreeCollectorBase() with
+                    override _.WalkCall (range : range) (mfv : FSharpMemberOrFunctionOrValue) (args : FSharpExpr list) =
+                        if
+                            seqFuncsWithEquivalentsInAllCollectionsArg0 |> Set.contains mfv.FullName
+                            && args.Length >= 1
+                        then
+                            match args[0] with
+                            | CoerceToSeqFromArrayOrListOrSet m -> state.Add (mfv.DisplayName, m, range)
+                            | _ -> ()
+                        else if
+                            seqFuncsWithEquivalentsInAllCollectionsArg1 |> Set.contains mfv.FullName
+                            && args.Length >= 2
+                        then
+                            match args[1] with
+                            | CoerceToSeqFromArrayOrListOrSet m -> state.Add (mfv.DisplayName, m, range)
+                            | _ -> ()
+                        else if
+                            seqFuncsWithEquivalentsInAllCollectionsArg2 |> Set.contains mfv.FullName
+                            && args.Length >= 3
+                        then
+                            match args[2] with
+                            | CoerceToSeqFromArrayOrListOrSet m -> state.Add (mfv.DisplayName, m, range)
+                            | _ -> ()
+                        else if
+                            seqFuncsWithEquivalentsInAllCollectionsArg1And2 |> Set.contains mfv.FullName
+                            && args.Length >= 2
+                        then
+                            match args[0], args[1] with
+                            | CoerceToSeqFromArrayOrListOrSet m1, CoerceToSeqFromArrayOrListOrSet m2 when m1 = m2 ->
+                                state.Add (mfv.DisplayName, m1, range)
+                            | _ -> ()
+                        else if
+                            seqFuncsWithEquivalentsInArrayAndListArg0 |> Set.contains mfv.FullName
+                            && args.Length >= 1
+                        then
+                            match args[0] with
+                            | CoerceToSeqFromArrayOrList m -> state.Add (mfv.DisplayName, m, range)
+                            | _ -> ()
+                        else if
+                            seqFuncsWithEquivalentsInArrayAndList |> Set.contains mfv.FullName
+                            && args.Length >= 2
+                        then
+                            match args[1] with
+                            | CoerceToSeqFromArrayOrList m -> state.Add (mfv.DisplayName, m, range)
+                            | _ -> ()
+                        else
+                            ()
+                }
+
+            match context.TypedTree with
+            | Some t -> t.Declarations |> List.iter (walkTast walker)
+            | None -> ()
+
+            return
+                [
+                    for seqFunc, valType, range in state do
+                        {
+                            Type = "VirtualCall analyzer"
+                            Message =
+                                $"Consider replacing the call of Seq.{seqFunc} with a function from the {valType} module to avoid the costs of virtual calls."
+                            Code = Code
+                            Severity = Warning
+                            Range = range
+                            Fixes = []
+                        }
+                ]
+        }

--- a/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="PartialAppAnalyzerTests.fs" />
     <Compile Include="JsonSerializerOptionsAnalyzerTests.fs" />
     <Compile Include="UnionCaseAnalyzerTests.fs" />
+    <Compile Include="VirtualCallAnalyzerTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Analyzers.Tests/VirtualCallAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/VirtualCallAnalyzerTests.fs
@@ -1,0 +1,59 @@
+namespace GR.FSharp.Analyzers.Tests
+
+module VirtualCallAnalyzerTests =
+
+    open System.Collections
+    open System.IO
+    open NUnit.Framework
+    open FSharp.Compiler.CodeAnalysis
+    open FSharp.Analyzers.SDK.Testing
+    open GR.FSharp.Analyzers
+    open GR.FSharp.Analyzers.Tests.Common
+
+    let mutable projectOptions : FSharpProjectOptions = FSharpProjectOptions.zero
+
+    [<SetUp>]
+    let Setup () =
+        task {
+            let! options = mkOptionsFromProject "net7.0" []
+
+            projectOptions <- options
+        }
+
+    type TestCases() =
+
+        interface IEnumerable with
+            member _.GetEnumerator () : IEnumerator =
+                constructTestCaseEnumerator [| "virtualcall" |]
+
+    [<TestCaseSource(typeof<TestCases>)>]
+    let VirtualCallTests (fileName : string) =
+        task {
+            let fileName = Path.Combine (dataFolder, fileName)
+
+            let! messages =
+                File.ReadAllText fileName
+                |> getContext projectOptions
+                |> VirtualCallAnalyzer.virtualCallAnalyzer
+
+            do! assertExpected fileName messages
+        }
+
+    type NegativeTestCases() =
+
+        interface IEnumerable with
+            member _.GetEnumerator () : IEnumerator =
+                constructTestCaseEnumerator [| "virtualcall" ; "negative" |]
+
+    [<TestCaseSource(typeof<NegativeTestCases>)>]
+    let NegativeTests (fileName : string) =
+        task {
+            let fileName = Path.Combine (dataFolder, fileName)
+
+            let! messages =
+                File.ReadAllText fileName
+                |> getContext projectOptions
+                |> VirtualCallAnalyzer.virtualCallAnalyzer
+
+            Assert.IsEmpty messages
+        }

--- a/tests/data/virtualcall/SeqAppendOnTwoLists.fs
+++ b/tests/data/virtualcall/SeqAppendOnTwoLists.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let myList1 = [1..10]
+    let myList2 = [100..1000]
+    Seq.append myList1 myList2 // should warn

--- a/tests/data/virtualcall/SeqAppendOnTwoLists.fs.expected
+++ b/tests/data/virtualcall/SeqAppendOnTwoLists.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (6,4 - 6,30) | Consider replacing the call of Seq.append with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqAverageByOnList.fs
+++ b/tests/data/virtualcall/SeqAverageByOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [1.0 .. 10.0]
+    Seq.averageBy id myList // should warn

--- a/tests/data/virtualcall/SeqAverageByOnList.fs.expected
+++ b/tests/data/virtualcall/SeqAverageByOnList.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,27) | Consider replacing the call of Seq.averageBy with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqAverageOnList.fs
+++ b/tests/data/virtualcall/SeqAverageOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [ 1.0 .. 10.0 ]
+    Seq.average myList // should warn

--- a/tests/data/virtualcall/SeqAverageOnList.fs.expected
+++ b/tests/data/virtualcall/SeqAverageOnList.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,22) | Consider replacing the call of Seq.average with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqContainsOnArray.fs
+++ b/tests/data/virtualcall/SeqContainsOnArray.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myArray = [| 1..10 |]
+    Seq.contains 2 myArray // should warn

--- a/tests/data/virtualcall/SeqContainsOnArray.fs.expected
+++ b/tests/data/virtualcall/SeqContainsOnArray.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,26) | Consider replacing the call of Seq.contains with a function from the Array module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqContainsOnList.fs
+++ b/tests/data/virtualcall/SeqContainsOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [1..10]
+    Seq.contains 2 myList // should warn

--- a/tests/data/virtualcall/SeqContainsOnList.fs.expected
+++ b/tests/data/virtualcall/SeqContainsOnList.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,25) | Consider replacing the call of Seq.contains with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqContainsOnSet.fs
+++ b/tests/data/virtualcall/SeqContainsOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1..10]
+    Seq.contains 2 mySet // should warn

--- a/tests/data/virtualcall/SeqContainsOnSet.fs.expected
+++ b/tests/data/virtualcall/SeqContainsOnSet.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,24) | Consider replacing the call of Seq.contains with a function from the Set module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqExceptOnSetAndSet.fs
+++ b/tests/data/virtualcall/SeqExceptOnSetAndSet.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let mySet1 = set [3;5]
+    let mySet2 = set [1..10]
+    Seq.except mySet1 mySet2 // should warn

--- a/tests/data/virtualcall/SeqExceptOnSetAndSet.fs.expected
+++ b/tests/data/virtualcall/SeqExceptOnSetAndSet.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (6,4 - 6,28) | Consider replacing the call of Seq.except with a function from the Set module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqFoldOnSet.fs
+++ b/tests/data/virtualcall/SeqFoldOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1..10]
+    Seq.fold (+) 0 mySet // should warn

--- a/tests/data/virtualcall/SeqFoldOnSet.fs.expected
+++ b/tests/data/virtualcall/SeqFoldOnSet.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,24) | Consider replacing the call of Seq.fold with a function from the Set module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqIsEmptyOnArray.fs
+++ b/tests/data/virtualcall/SeqIsEmptyOnArray.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myArray = [| 1..10 |]
+    Seq.isEmpty myArray // should warn

--- a/tests/data/virtualcall/SeqIsEmptyOnArray.fs.expected
+++ b/tests/data/virtualcall/SeqIsEmptyOnArray.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,23) | Consider replacing the call of Seq.isEmpty with a function from the Array module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqIsEmptyOnSet.fs
+++ b/tests/data/virtualcall/SeqIsEmptyOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [ 1..10 ]
+    Seq.isEmpty mySet // should warn

--- a/tests/data/virtualcall/SeqIsEmptyOnSet.fs.expected
+++ b/tests/data/virtualcall/SeqIsEmptyOnSet.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,21) | Consider replacing the call of Seq.isEmpty with a function from the Set module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqMap3OnLists.fs
+++ b/tests/data/virtualcall/SeqMap3OnLists.fs
@@ -1,0 +1,7 @@
+module M
+
+let f () =
+    let myList1 = [100..1000]
+    let myList2 = [100..1000]
+    let myList3 = [100..1000]
+    Seq.map3 (fun x y z -> x + y + z) myList1 myList2 myList3 // should warn

--- a/tests/data/virtualcall/SeqMap3OnLists.fs.expected
+++ b/tests/data/virtualcall/SeqMap3OnLists.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (7,4 - 7,61) | Consider replacing the call of Seq.map3 with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/SeqTransposeOnList.fs
+++ b/tests/data/virtualcall/SeqTransposeOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [ [1]; [2]; [3] ]
+    Seq.transpose myList // should not warn

--- a/tests/data/virtualcall/SeqTransposeOnList.fs.expected
+++ b/tests/data/virtualcall/SeqTransposeOnList.fs.expected
@@ -1,0 +1,1 @@
+GRA-VIRTUALCALL-001 | Warning | (5,4 - 5,24) | Consider replacing the call of Seq.transpose with a function from the List module to avoid the costs of virtual calls.

--- a/tests/data/virtualcall/negative/ListAverageByOnList.fs
+++ b/tests/data/virtualcall/negative/ListAverageByOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [1.0 .. 10.0]
+    List.averageBy id myList // should not warn

--- a/tests/data/virtualcall/negative/ListAverageOnList.fs
+++ b/tests/data/virtualcall/negative/ListAverageOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [1.0 .. 10.0]
+    List.average myList // should not warn

--- a/tests/data/virtualcall/negative/ListTransposeOnList.fs
+++ b/tests/data/virtualcall/negative/ListTransposeOnList.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let myList = [ [1]; [2]; [3] ]
+    List.transpose myList // should not warn

--- a/tests/data/virtualcall/negative/SeqAppendOnSeqAndList.fs
+++ b/tests/data/virtualcall/negative/SeqAppendOnSeqAndList.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let mySeq = Seq.ofList [1..10]
+    let myList = [100..1000]
+    Seq.append mySeq myList // should not warn

--- a/tests/data/virtualcall/negative/SeqAppendOnSet.fs
+++ b/tests/data/virtualcall/negative/SeqAppendOnSet.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let mySet1 = set [1..10]
+    let mySet2 = set [7..10]
+    Seq.append mySet1 mySet2 // should not warn

--- a/tests/data/virtualcall/negative/SeqAppendOnTwoSeqs.fs
+++ b/tests/data/virtualcall/negative/SeqAppendOnTwoSeqs.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let mySeq1 = Seq.ofList [1..10]
+    let mySeq2 = Seq.ofList [100..1000]
+    Seq.append mySeq1 mySeq2 // should not warn

--- a/tests/data/virtualcall/negative/SeqAverageOnSet.fs
+++ b/tests/data/virtualcall/negative/SeqAverageOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1.0 .. 10.0]
+    Seq.average mySet // should not warn

--- a/tests/data/virtualcall/negative/SeqExceptOnSetAndList.fs
+++ b/tests/data/virtualcall/negative/SeqExceptOnSetAndList.fs
@@ -1,0 +1,6 @@
+module M
+
+let f () =
+    let myList = [3;5]
+    let mySet = set [1..10]
+    Seq.except myList mySet // should not warn

--- a/tests/data/virtualcall/negative/SeqMap3OnSeqsAndList.fs
+++ b/tests/data/virtualcall/negative/SeqMap3OnSeqsAndList.fs
@@ -1,0 +1,7 @@
+module M
+
+let f () =
+    let mySeq1 = Seq.ofList [1..10]
+    let mySeq2 = Seq.ofList [1..10]
+    let myList = [100..1000]
+    Seq.map3 (fun x y z -> x + y + z) mySeq1 myList mySeq2 // should not warn

--- a/tests/data/virtualcall/negative/SeqRevOnSet.fs
+++ b/tests/data/virtualcall/negative/SeqRevOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1..10]
+    Seq.rev mySet // should not warn

--- a/tests/data/virtualcall/negative/SetContainsOnSet.fs
+++ b/tests/data/virtualcall/negative/SetContainsOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1..10]
+    Set.contains 2 mySet // should not warn

--- a/tests/data/virtualcall/negative/SetFoldOnSet.fs
+++ b/tests/data/virtualcall/negative/SetFoldOnSet.fs
@@ -1,0 +1,5 @@
+module M
+
+let f () =
+    let mySet = set [1..10]
+    Set.fold (+) 0 mySet // should not warn


### PR DESCRIPTION
@Smaug123 Would you like to see warnings for all functions from the Seq module with equivalents in List|Array|Set or is there a known subset that is definitely causing expensive virtual calls?

I'm not sure, there's a reasonable way to check programmatically if we would end up with a virtual call for a Seq function.