### PR TITLE
Add TypeAnnotateStringFunction analyzer.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.3.0-alpha-002",
+      "version": "6.3.0-alpha-003",
       "commands": [
         "fantomas"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.20.2",
+      "version": "0.21.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,9 +9,15 @@
       ]
     },
     "fsdocs-tool": {
-      "version": "20.0.0-alpha-013",
+      "version": "20.0.0-alpha-014",
       "commands": [
         "fsdocs"
+      ]
+    },
+    "fsharp-analyzers": {
+      "version": "0.20.2",
+      "commands": [
+        "fsharp-analyzers"
       ]
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 - 2023-11-23
+
+### Added
+* Add TypeAnnotateStringFunction analyzer. [#34](https://github.com/G-Research/fsharp-analyzers/pull/34)
+
+### Changed
+* Update FSharp.Analyzers.SDK to `0.21.0`. [#34](https://github.com/G-Research/fsharp-analyzers/pull/34)
+
 ## 0.3.1 - 2023-11-15
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,9 @@
         <ServerGarbageCollection>true</ServerGarbageCollection>
         <LangVersion>preview</LangVersion>
         <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen</OtherFlags>
+        <!-- Set to true and adjust the path to your local repo if you want to use that instead of the nuget packages -->
+        <UseLocalAnalyzersSDK>false</UseLocalAnalyzersSDK>
+        <LocalAnalyzersSDKRepo>../../../FSharp.Analyzers.SDK</LocalAnalyzersSDKRepo>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- locking the version of F# Core as FCS does this anyway and in practise all will be using the same version -->
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.20.2]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="0.20.2" />
-    <PackageVersion Include="FSharp.Core" Version="[7.0.400]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.7.400]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.21.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.21.0]" />
+    <PackageVersion Include="FSharp.Core" Version="[8.0.100]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.100]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/docs/analyzers/TypeAnnotateStringFunction.md
+++ b/docs/analyzers/TypeAnnotateStringFunction.md
@@ -12,7 +12,7 @@ index: 6
 Using the `string` function can catch you off guard when refactoring types.
 
 ```fsharp
-let v = 1 // Changing this value won't affect `s`
+let v = 1 // Changing the type won't affect `s`
 let s = string v
 ```
 
@@ -21,6 +21,6 @@ let s = string v
 Add an explicit type annotation:
 
 ```fsharp
-let v = 1 // Changing this will affect `s`
+let v = 1 // Changing the type will affect `s`
 let s = string<int> v
 ```

--- a/docs/analyzers/TypeAnnotateStringFunction.md
+++ b/docs/analyzers/TypeAnnotateStringFunction.md
@@ -1,0 +1,26 @@
+---
+title: TypeAnnotateStringFunctionAnalyzer
+category: analyzers
+categoryindex: 1
+index: 6
+---
+
+# TypeAnnotateStringFunction
+
+## Problem
+
+Using the `string` function can catch you off guard when refactoring types.
+
+```fsharp
+let v = 1 // Changing this value won't affect `s`
+let s = string v
+```
+
+## Fix
+
+Add an explicit type annotation:
+
+```fsharp
+let v = 1 // Changing this will affect `s`
+let s = string<int> v
+```

--- a/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
+++ b/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
@@ -20,6 +20,7 @@
         <Compile Include="PartialAppAnalyzer.fs" />
         <Compile Include="VirtualCallAnalyzer.fsi" />
         <Compile Include="VirtualCallAnalyzer.fs" />
+        <Compile Include="TypeAnnotateStringFunction.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
+++ b/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
@@ -23,10 +23,16 @@
         <Compile Include="TypeAnnotateStringFunction.fs" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'true'">
+        <ProjectReference Include="$(LocalAnalyzersSDKRepo)/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj" />
+    </ItemGroup>
+    
     <ItemGroup>
         <PackageReference Update="FSharp.Core" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
         <PackageReference Include="FSharp.Analyzers.SDK"/>
-        <PackageReference Include="FSharp.Compiler.Service"/>
     </ItemGroup>
 
     <Target Name="_AddAnalyzersToOutput">

--- a/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
+++ b/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
@@ -36,7 +36,7 @@ type StringApplicationResult =
 let (|StringFunctionExpr|_|) =
     function
     | SynExpr.Ident (ident = ident) when ident.idText = "string" -> Some ()
-    | SynExpr.LongIdent(longDotId = SynLongIdent(id = lid)) ->
+    | SynExpr.LongIdent (longDotId = SynLongIdent (id = lid)) ->
         List.tryLast lid
         |> Option.bind (fun ident -> if ident.idText = "string" then Some () else None)
     | _ -> None
@@ -60,9 +60,10 @@ let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
                                 // in this case expression was probably piped into the string function.
                                 | StringFunctionExpr ->
                                     match path with
-                                    | SyntaxNode.SynExpr (SynExpr.TypeApp _) :: _ -> Some StringApplicationResult.TypeArgument
+                                    | SyntaxNode.SynExpr (SynExpr.TypeApp _) :: _ ->
+                                        Some StringApplicationResult.TypeArgument
                                     | _ -> Some StringApplicationResult.NoTypeArgument
-                                
+
                                 | SynExpr.App (funcExpr = StringFunctionExpr) ->
                                     Some StringApplicationResult.NoTypeArgument
 
@@ -88,9 +89,11 @@ let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
                         if mfv.FullName = "Microsoft.FSharp.Core.Operators.string" && args.Length = 1 then
                             match tryFindSynExprApp m with
                             | Some (StringApplicationResult.Unsure sourceCode) ->
-                                #if DEBUG
+#if DEBUG
                                 printfn $"Could map %A{m} to an string application, source:\n%s{sourceCode}"
-                                #endif
+#else
+                                ignore sourceCode
+#endif
                             | Some StringApplicationResult.NoTypeArgument ->
                                 messages.Add
                                     {
@@ -103,9 +106,11 @@ let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
                                     }
                             | Some StringApplicationResult.TypeArgument -> ()
                             | None ->
-                                #if DEBUG
+#if DEBUG
                                 printfn $"Could not find application for %A{m}"
-                                #endif
+#else
+                                ()
+#endif
                 }
 
             match ctx.TypedTree with

--- a/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
+++ b/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
@@ -90,7 +90,7 @@ let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
                             match tryFindSynExprApp m with
                             | Some (StringApplicationResult.Unsure sourceCode) ->
 #if DEBUG
-                                printfn $"Could map %A{m} to an string application, source:\n%s{sourceCode}"
+                                printfn $"Could map %A{m} to a string application, source:\n%s{sourceCode}"
 #else
                                 ignore sourceCode
 #endif

--- a/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
+++ b/src/FSharp.Analyzers/TypeAnnotateStringFunction.fs
@@ -1,0 +1,116 @@
+module GR.FSharp.Analyzers.TypeAnnotateStringFunction
+
+open System.Text
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.TASTCollecting
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+
+type ISourceText with
+
+    member x.GetContentAt (range : range) : string =
+        let startLine = range.StartLine - 1
+        let line = x.GetLineString startLine
+
+        if range.StartLine = range.EndLine then
+            let length = range.EndColumn - range.StartColumn
+            line.Substring (range.StartColumn, length)
+        else
+            let firstLineContent = line.Substring range.StartColumn
+            let sb = StringBuilder().AppendLine firstLineContent
+
+            (sb, [ range.StartLine .. range.EndLine - 2 ])
+            ||> List.fold (fun sb lineNumber -> sb.AppendLine (x.GetLineString lineNumber))
+            |> fun sb ->
+                let lastLine = x.GetLineString (range.EndLine - 1)
+
+                sb.Append(lastLine.Substring (0, range.EndColumn)).ToString ()
+
+[<RequireQualifiedAccess>]
+type StringApplicationResult =
+    | NoTypeArgument
+    | TypeArgument
+    | Unsure of string
+
+let (|StringFunctionExpr|_|) =
+    function
+    | SynExpr.Ident (ident = ident) when ident.idText = "string" -> Some ()
+    | SynExpr.LongIdent(longDotId = SynLongIdent(id = lid)) ->
+        List.tryLast lid
+        |> Option.bind (fun ident -> if ident.idText = "string" then Some () else None)
+    | _ -> None
+
+[<CliAnalyzer("TypeAnnotateStringFunctionAnalyzer",
+              "Checks if the `string` function call is type annotated.",
+              "https://g-research.github.io/fsharp-analyzers/analyzers/TypeAnnotateStringFunctionAnalyzer.html")>]
+let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
+    fun (ctx : CliContext) ->
+        async {
+            let messages = ResizeArray<Message> ()
+
+            let tryFindSynExprApp (m : range) =
+                let visitor =
+                    { new SyntaxVisitorBase<StringApplicationResult>() with
+                        override x.VisitExpr (path, traverseSynExpr, defaultTraverse, synExpr) =
+                            if not (Range.equals synExpr.Range m) then
+                                defaultTraverse synExpr
+                            else
+                                match synExpr with
+                                // in this case expression was probably piped into the string function.
+                                | StringFunctionExpr ->
+                                    match path with
+                                    | SyntaxNode.SynExpr (SynExpr.TypeApp _) :: _ -> Some StringApplicationResult.TypeArgument
+                                    | _ -> Some StringApplicationResult.NoTypeArgument
+                                
+                                | SynExpr.App (funcExpr = StringFunctionExpr) ->
+                                    Some StringApplicationResult.NoTypeArgument
+
+                                | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = StringFunctionExpr)) ->
+                                    Some StringApplicationResult.TypeArgument
+                                | e ->
+                                    let source = ctx.SourceText.GetContentAt e.Range
+                                    Some (StringApplicationResult.Unsure source)
+                    }
+
+                SyntaxTraversal.Traverse (m.Start, ctx.ParseFileResults.ParseTree, visitor)
+
+            let tastCollector =
+                { new TypedTreeCollectorBase() with
+                    override x.WalkCall
+                        _
+                        (mfv : FSharpMemberOrFunctionOrValue)
+                        objExprTypeArgs
+                        memberOrFuncTypeArgs
+                        (args : FSharpExpr list)
+                        (m : range)
+                        =
+                        if mfv.FullName = "Microsoft.FSharp.Core.Operators.string" && args.Length = 1 then
+                            match tryFindSynExprApp m with
+                            | Some (StringApplicationResult.Unsure sourceCode) ->
+                                #if DEBUG
+                                printfn $"Could map %A{m} to an string application, source:\n%s{sourceCode}"
+                                #endif
+                            | Some StringApplicationResult.NoTypeArgument ->
+                                messages.Add
+                                    {
+                                        Type = "TypeAnnotateStringFunctionsAnalyzer"
+                                        Message = "Please annotate your type when using the `string` function."
+                                        Code = "GRA-TYPE-ANNOTATE-001"
+                                        Severity = Severity.Warning
+                                        Range = m
+                                        Fixes = []
+                                    }
+                            | Some StringApplicationResult.TypeArgument -> ()
+                            | None ->
+                                #if DEBUG
+                                printfn $"Could not find application for %A{m}"
+                                #endif
+                }
+
+            match ctx.TypedTree with
+            | None -> return []
+            | Some typedTree ->
+                walkTast tastCollector typedTree
+                return Seq.toList messages
+        }

--- a/tests/FSharp.Analyzers.Tests/Common.fs
+++ b/tests/FSharp.Analyzers.Tests/Common.fs
@@ -14,6 +14,9 @@ let shouldUpdateBaseline () =
     |> Option.map (fun v -> v.Trim () = "1")
     |> Option.defaultValue false
 
+/// Update by:
+/// set TEST_UPDATE_BSL=1
+/// $env:TEST_UPDATE_BSL=1
 let assertExpected sourceFile messages =
     task {
         let actualContents =

--- a/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
@@ -21,7 +21,7 @@
 
     <ItemGroup>
         <PackageReference Update="FSharp.Core"/>
-        <PackageReference Include="FSharp.Analyzers.SDK.Testing"/>
+        <PackageReference Include="FSharp.Analyzers.SDK.Testing" Condition="'$(UseLocalAnalyzersSDK)' == 'false'" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NUnit"/>
         <PackageReference Include="NUnit3TestAdapter"/>

--- a/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
@@ -1,36 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-    <GenerateProgramFile>false</GenerateProgramFile>
-    <IsTestProject>true</IsTestProject>
-    <AssemblyName>G-Research.FSharp.Analyzers.Tests</AssemblyName>
-  </PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <GenerateProgramFile>false</GenerateProgramFile>
+        <IsTestProject>true</IsTestProject>
+        <AssemblyName>G-Research.FSharp.Analyzers.Tests</AssemblyName>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="Common.fs" />
-    <Compile Include="StringAnalyzerTests.fs" />
-    <Compile Include="PartialAppAnalyzerTests.fs" />
-    <Compile Include="JsonSerializerOptionsAnalyzerTests.fs" />
-    <Compile Include="UnionCaseAnalyzerTests.fs" />
-    <Compile Include="VirtualCallAnalyzerTests.fs" />
-    <Compile Include="TypeAnnotateStringFunctionAnalyzerTests.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Common.fs"/>
+        <Compile Include="StringAnalyzerTests.fs"/>
+        <Compile Include="PartialAppAnalyzerTests.fs"/>
+        <Compile Include="JsonSerializerOptionsAnalyzerTests.fs"/>
+        <Compile Include="UnionCaseAnalyzerTests.fs"/>
+        <Compile Include="VirtualCallAnalyzerTests.fs"/>
+        <Compile Include="TypeAnnotateStringFunctionAnalyzerTests.fs"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" />
-    <PackageReference Include="FSharp.Analyzers.SDK.Testing" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core"/>
+        <PackageReference Include="FSharp.Analyzers.SDK.Testing"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NUnit"/>
+        <PackageReference Include="NUnit3TestAdapter"/>
+        <PackageReference Include="NUnit.Analyzers"/>
+        <PackageReference Include="coverlet.collector"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FSharp.Analyzers\FSharp.Analyzers.fsproj" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
+        <PackageReference Include="FSharp.Analyzers.SDK.Testing"/>
+    </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\FSharp.Analyzers\FSharp.Analyzers.fsproj"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'true'">
+        <ProjectReference Include="$(LocalAnalyzersSDKRepo)/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsproj" />
+    </ItemGroup>
 </Project>

--- a/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="JsonSerializerOptionsAnalyzerTests.fs" />
     <Compile Include="UnionCaseAnalyzerTests.fs" />
     <Compile Include="VirtualCallAnalyzerTests.fs" />
+    <Compile Include="TypeAnnotateStringFunctionAnalyzerTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Tests/FSharp.Analyzers.Tests.fsproj
@@ -21,7 +21,6 @@
 
     <ItemGroup>
         <PackageReference Update="FSharp.Core"/>
-        <PackageReference Include="FSharp.Analyzers.SDK.Testing" Condition="'$(UseLocalAnalyzersSDK)' == 'false'" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NUnit"/>
         <PackageReference Include="NUnit3TestAdapter"/>

--- a/tests/FSharp.Analyzers.Tests/TypeAnnotateStringFunctionAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/TypeAnnotateStringFunctionAnalyzerTests.fs
@@ -1,0 +1,57 @@
+module GR.FSharp.Analyzers.Tests.TypeAnnotateStringFunctionAnalyzerTests
+
+open System.Collections
+open System.IO
+open NUnit.Framework
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Analyzers.SDK.Testing
+open GR.FSharp.Analyzers
+open GR.FSharp.Analyzers.Tests.Common
+
+let mutable projectOptions : FSharpProjectOptions = FSharpProjectOptions.zero
+
+[<SetUp>]
+let Setup () =
+    task {
+        let! options = mkOptionsFromProject "net7.0" []
+
+        projectOptions <- options
+    }
+
+type TestCases() =
+
+    interface IEnumerable with
+        member _.GetEnumerator () : IEnumerator =
+            constructTestCaseEnumerator [| "typeAnnotateStringFunctions" |]
+
+[<TestCaseSource(typeof<TestCases>)>]
+let TypeAnnotateStringFunctionsTests (fileName : string) =
+    task {
+        let fileName = Path.Combine (dataFolder, fileName)
+
+        let! messages =
+            File.ReadAllText fileName
+            |> getContext projectOptions
+            |> TypeAnnotateStringFunction.typeAnnotateStringFunctionsAnalyzer
+
+        do! assertExpected fileName messages
+    }
+
+type NegativeTestCases() =
+
+    interface IEnumerable with
+        member _.GetEnumerator () : IEnumerator =
+            constructTestCaseEnumerator [| "typeAnnotateStringFunctions" ; "negative" |]
+
+[<TestCaseSource(typeof<NegativeTestCases>)>]
+let NegativeTests (fileName : string) =
+    task {
+        let fileName = Path.Combine (dataFolder, fileName)
+
+        let! messages =
+            File.ReadAllText fileName
+            |> getContext projectOptions
+            |> TypeAnnotateStringFunction.typeAnnotateStringFunctionsAnalyzer
+
+        Assert.IsEmpty messages
+    }

--- a/tests/data/typeAnnotateStringFunctions/AliasStringFunction.fs
+++ b/tests/data/typeAnnotateStringFunctions/AliasStringFunction.fs
@@ -1,0 +1,5 @@
+module S
+
+let foo = Microsoft.FSharp.Core.Operators.string
+do
+    foo 9.3

--- a/tests/data/typeAnnotateStringFunctions/AliasStringFunction.fs.expected
+++ b/tests/data/typeAnnotateStringFunctions/AliasStringFunction.fs.expected
@@ -1,0 +1,1 @@
+GRA-TYPE-ANNOTATE-001 | Warning | (3,10 - 3,48) | Please annotate your type when using the `string` function.

--- a/tests/data/typeAnnotateStringFunctions/FullyQualifiedStringFunctionWithRecord.fs
+++ b/tests/data/typeAnnotateStringFunctions/FullyQualifiedStringFunctionWithRecord.fs
@@ -1,0 +1,10 @@
+module S
+
+type Coordinate = { X : int; Y: int }
+
+let v =
+    Microsoft.FSharp.Core.Operators.string
+        {
+            X = 1
+            Y = 2
+        }

--- a/tests/data/typeAnnotateStringFunctions/FullyQualifiedStringFunctionWithRecord.fs.expected
+++ b/tests/data/typeAnnotateStringFunctions/FullyQualifiedStringFunctionWithRecord.fs.expected
@@ -1,0 +1,1 @@
+GRA-TYPE-ANNOTATE-001 | Warning | (6,4 - 10,9) | Please annotate your type when using the `string` function.

--- a/tests/data/typeAnnotateStringFunctions/PipedStringFunction.fs
+++ b/tests/data/typeAnnotateStringFunctions/PipedStringFunction.fs
@@ -1,0 +1,5 @@
+module S
+
+let v =
+    9001
+    |> string

--- a/tests/data/typeAnnotateStringFunctions/PipedStringFunction.fs.expected
+++ b/tests/data/typeAnnotateStringFunctions/PipedStringFunction.fs.expected
@@ -1,0 +1,1 @@
+GRA-TYPE-ANNOTATE-001 | Warning | (5,7 - 5,13) | Please annotate your type when using the `string` function.

--- a/tests/data/typeAnnotateStringFunctions/StringWithPrimitive.fs
+++ b/tests/data/typeAnnotateStringFunctions/StringWithPrimitive.fs
@@ -1,0 +1,4 @@
+module S
+
+do
+    string 1

--- a/tests/data/typeAnnotateStringFunctions/StringWithPrimitive.fs.expected
+++ b/tests/data/typeAnnotateStringFunctions/StringWithPrimitive.fs.expected
@@ -1,0 +1,1 @@
+GRA-TYPE-ANNOTATE-001 | Warning | (4,4 - 4,12) | Please annotate your type when using the `string` function.

--- a/tests/data/typeAnnotateStringFunctions/StringWithType.fs
+++ b/tests/data/typeAnnotateStringFunctions/StringWithType.fs
@@ -1,0 +1,5 @@
+module S
+
+type X() = class end
+
+let v = string (X())

--- a/tests/data/typeAnnotateStringFunctions/StringWithType.fs.expected
+++ b/tests/data/typeAnnotateStringFunctions/StringWithType.fs.expected
@@ -1,0 +1,1 @@
+GRA-TYPE-ANNOTATE-001 | Warning | (5,8 - 5,20) | Please annotate your type when using the `string` function.

--- a/tests/data/typeAnnotateStringFunctions/negative/FullyQualifiedStringFunctionWithRecord.fs
+++ b/tests/data/typeAnnotateStringFunctions/negative/FullyQualifiedStringFunctionWithRecord.fs
@@ -1,0 +1,10 @@
+module S
+
+type Coordinate = { X : int; Y: int }
+
+let v =
+    Microsoft.FSharp.Core.Operators.string<Coordinate>
+        {
+            X = 1
+            Y = 2
+        }

--- a/tests/data/typeAnnotateStringFunctions/negative/PipedStringFunction.fs
+++ b/tests/data/typeAnnotateStringFunctions/negative/PipedStringFunction.fs
@@ -1,0 +1,5 @@
+module S
+
+let v =
+    9001
+    |> string<int>

--- a/tests/data/typeAnnotateStringFunctions/negative/StringWithPrimitive.fs
+++ b/tests/data/typeAnnotateStringFunctions/negative/StringWithPrimitive.fs
@@ -1,0 +1,4 @@
+module S
+
+do
+    string<int> 1

--- a/tests/data/typeAnnotateStringFunctions/negative/StringWithType.fs
+++ b/tests/data/typeAnnotateStringFunctions/negative/StringWithType.fs
@@ -1,0 +1,5 @@
+module S
+
+type X() = class end
+
+let v = string<X> (X())


### PR DESCRIPTION
This one is a little tricky and won't work in some more extreme situations.
If someone were to alias the `string` from `FSharp.Core` it will go unnoticed.
I think this is a reasonable trade-off.

Please already review @dawedawe. I will look into the `ToString()` in a different PR.