### PR TITLE
Handle fullname more gracefully and do a bugfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## 0.5.1 - 2023-12-06
+
+### Fixed
+* Handle types without a FullName more gracefully. [#39](https://github.com/G-Research/fsharp-analyzers/pull/39)
+
 ## 0.5.0 - 2023-12-04
 
 ### Added
-* Add ImmutableCollectionEquality analyzer. [#34](https://github.com/G-Research/fsharp-analyzers/pull/37)
-* Add LoggingArgFuncNotFullyApplied analyzer. [#34](https://github.com/G-Research/fsharp-analyzers/pull/38)
+* Add ImmutableCollectionEquality analyzer. [#37](https://github.com/G-Research/fsharp-analyzers/pull/37)
+* Add LoggingArgFuncNotFullyApplied analyzer. [#38](https://github.com/G-Research/fsharp-analyzers/pull/38)
 
 ## 0.4.0 - 2023-11-23
 

--- a/src/FSharp.Analyzers/ImmutableCollectionEqualityAnalyzer.fs
+++ b/src/FSharp.Analyzers/ImmutableCollectionEqualityAnalyzer.fs
@@ -18,7 +18,13 @@ let isImmutableType (basicQualifiedName : string) (e : FSharpExpr) =
 
     let t = e.Type
 
-    t.BasicQualifiedName = basicQualifiedName
+    let basicQualifiedNameOfExprType =
+        if t.ErasedType.HasTypeDefinition then
+            t.ErasedType.TypeDefinition.TryGetFullName () |> Option.defaultValue ""
+        else
+            ""
+
+    basicQualifiedNameOfExprType = basicQualifiedName
     && t.TypeDefinition.Assembly.SimpleName = "System.Collections.Immutable"
 
 let isImmutableDictionaryType (e : FSharpExpr) =
@@ -39,7 +45,7 @@ let mkMessage typeName m =
     }
 
 [<CliAnalyzer("ImmutableCollectionEqualityAnalyzer",
-              "TODO: add description.",
+              "Warns about questionable comparison operations among immutable collections",
               "https://g-research.github.io/fsharp-analyzers/analyzers/ImmutableCollectionEqualityAnalyzer.html")>]
 let immutableCollectionEqualityAnalyzer : Analyzer<CliContext> =
     fun (ctx : CliContext) ->

--- a/src/FSharp.Analyzers/StringAnalyzer.fs
+++ b/src/FSharp.Analyzers/StringAnalyzer.fs
@@ -16,9 +16,7 @@ let StringIndexOfCode = "GRA-STRING-003"
 
 let tryGetFullName (e : FSharpExpr) =
     if e.Type.ErasedType.HasTypeDefinition then
-        match e.Type.ErasedType.TypeDefinition.TryGetFullName () with
-        | Some n -> Some n
-        | _ -> None
+        e.Type.ErasedType.TypeDefinition.TryGetFullName ()
     else
         None
 

--- a/src/FSharp.Analyzers/StringAnalyzer.fs
+++ b/src/FSharp.Analyzers/StringAnalyzer.fs
@@ -14,15 +14,24 @@ let StringStartsWithCode = "GRA-STRING-002"
 [<Literal>]
 let StringIndexOfCode = "GRA-STRING-003"
 
-let (|StringExpr|_|) (e : FSharpExpr) =
-    if e.Type.ErasedType.BasicQualifiedName = "System.String" then
-        Some ()
+let tryGetFullName (e : FSharpExpr) =
+    if e.Type.ErasedType.HasTypeDefinition then
+        match e.Type.ErasedType.TypeDefinition.TryGetFullName () with
+        | Some n -> Some n
+        | _ -> None
     else
         None
 
+let (|StringExpr|_|) (e : FSharpExpr) =
+    match tryGetFullName e with
+    | Some "System.String" -> Some ()
+    | _ -> None
+
 let (|IntExpr|_|) (e : FSharpExpr) =
-    if e.Type.ErasedType.BasicQualifiedName = "System.Int32" then
-        Some ()
+    if e.Type.ErasedType.HasTypeDefinition then
+        match tryGetFullName e with
+        | Some "System.Int32" -> Some ()
+        | _ -> None
     else
         None
 


### PR DESCRIPTION
The rest of the exceptions we see are from [here](https://github.com/dotnet/fsharp/blob/b311526f48a5a6e65079dc2e6942349509e3014d/src/Compiler/Symbols/Exprs.fs#L1177) when the TAST is walked.
Need to look deeper if we can do something about that.