### PR TITLE
Ignore formattableStrings in TypedInterpolatedStringsAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+* Don't report FormattableStrings in TypedInterpolatedStringsAnalyzer. [#46](https://github.com/G-Research/fsharp-analyzers/pull/46)
+
 ## 0.6.0 - 2023-12-20
 
 ### Added

--- a/tests/data/typedInterpolatedStrings/negative/FormattableString.fs
+++ b/tests/data/typedInterpolatedStrings/negative/FormattableString.fs
@@ -1,0 +1,7 @@
+module IF
+
+open System
+
+let a (b: FormattableString) = ()
+do 
+    a $"foo {42} bar"


### PR DESCRIPTION
When an interpolated string is used as [FormattableString](https://learn.microsoft.com/en-us/dotnet/api/system.formattablestring?view=net-8.0) it cannot accept any explicit annotations.

I'm filtering these out.