### PR TITLE
Add editor support to all analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 * Don't report FormattableStrings in TypedInterpolatedStringsAnalyzer. [#46](https://github.com/G-Research/fsharp-analyzers/pull/46)
 
+### Added
+* Add editor support to all analyzers. [#50](https://github.com/G-Research/fsharp-analyzers/pull/50)
+
 ## 0.6.0 - 2023-12-20
 
 ### Added

--- a/src/FSharp.Analyzers/ImmutableCollectionEqualityAnalyzer.fs
+++ b/src/FSharp.Analyzers/ImmutableCollectionEqualityAnalyzer.fs
@@ -44,56 +44,66 @@ let mkMessage typeName m =
         Fixes = []
     }
 
-[<CliAnalyzer("ImmutableCollectionEqualityAnalyzer",
-              "Warns about questionable comparison operations among immutable collections",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/ImmutableCollectionEqualityAnalyzer.html")>]
-let immutableCollectionEqualityAnalyzer : Analyzer<CliContext> =
-    fun (ctx : CliContext) ->
-        async {
+let analyze (typedTree : FSharpImplementationFileContents) =
+    let invocations = ResizeArray<Message> ()
 
-            let invocations = ResizeArray<Message> ()
+    let walker =
+        { new TypedTreeCollectorBase() with
+            override _.WalkCall
+                (objExprOpt : FSharpExpr option)
+                (mfv : FSharpMemberOrFunctionOrValue)
+                _
+                _
+                (args : FSharpExpr list)
+                (m : range)
+                =
+                let xsOpt =
+                    if
+                        (mfv.FullName = "System.Object.Equals")
+                        && (mfv.Assembly.SimpleName = "System.Runtime"
+                            || mfv.Assembly.SimpleName = "netstandard")
+                        && args.Length = 1
+                    then
+                        objExprOpt |> Option.map (fun objExpr -> args.[0], objExpr)
+                    elif
+                        (mfv.FullName = "Microsoft.FSharp.Core.Operators.(=)"
+                         || mfv.FullName = "Microsoft.FSharp.Core.Operators.(<>)")
+                        && mfv.Assembly.SimpleName = "FSharp.Core"
+                        && args.Length = 2
+                    then
+                        Some (args.[0], args.[1])
+                    else
+                        None
 
-            let walker =
-                { new TypedTreeCollectorBase() with
-                    override _.WalkCall
-                        (objExprOpt : FSharpExpr option)
-                        (mfv : FSharpMemberOrFunctionOrValue)
-                        _
-                        _
-                        (args : FSharpExpr list)
-                        (m : range)
-                        =
-                        let xsOpt =
-                            if
-                                (mfv.FullName = "System.Object.Equals")
-                                && (mfv.Assembly.SimpleName = "System.Runtime"
-                                    || mfv.Assembly.SimpleName = "netstandard")
-                                && args.Length = 1
-                            then
-                                objExprOpt |> Option.map (fun objExpr -> args.[0], objExpr)
-                            elif
-                                (mfv.FullName = "Microsoft.FSharp.Core.Operators.(=)"
-                                 || mfv.FullName = "Microsoft.FSharp.Core.Operators.(<>)")
-                                && mfv.Assembly.SimpleName = "FSharp.Core"
-                                && args.Length = 2
-                            then
-                                Some (args.[0], args.[1])
-                            else
-                                None
+                match xsOpt with
+                | None -> ()
+                | Some (e1, e2) ->
 
-                        match xsOpt with
-                        | None -> ()
-                        | Some (e1, e2) ->
-
-                        if isImmutableDictionaryType e1 && isImmutableDictionaryType e2 then
-                            invocations.Add (mkMessage "System.Collections.Immutable.ImmutableDictionary" m)
-                        elif isImmutableHashSetType e1 && isImmutableHashSetType e2 then
-                            invocations.Add (mkMessage "System.Collections.Immutable.ImmutableHashSet" m)
-                }
-
-            match ctx.TypedTree with
-            | None -> return List.empty<Message>
-            | Some typedTree ->
-                walkTast walker typedTree
-                return Seq.toList invocations
+                if isImmutableDictionaryType e1 && isImmutableDictionaryType e2 then
+                    invocations.Add (mkMessage "System.Collections.Immutable.ImmutableDictionary" m)
+                elif isImmutableHashSetType e1 && isImmutableHashSetType e2 then
+                    invocations.Add (mkMessage "System.Collections.Immutable.ImmutableHashSet" m)
         }
+
+
+    walkTast walker typedTree
+    Seq.toList invocations
+
+[<Literal>]
+let Name = "ImmutableCollectionEqualityAnalyzer"
+
+[<Literal>]
+let ShortDescription =
+    "Warns about questionable comparison operations among immutable collections"
+
+[<Literal>]
+let HelpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/ImmutableCollectionEqualityAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+let immutableCollectionEqualityCliAnalyzer : Analyzer<CliContext> =
+    fun (ctx : CliContext) -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+let immutableCollectionEqualityEditorAnalyzer : Analyzer<EditorContext> =
+    fun (ctx : EditorContext) -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }

--- a/src/FSharp.Analyzers/JsonSerializerOptionsAnalyzer.fs
+++ b/src/FSharp.Analyzers/JsonSerializerOptionsAnalyzer.fs
@@ -11,74 +11,78 @@ open FSharp.Compiler.Symbols.FSharpExprPatterns
 [<Literal>]
 let Code = "GRA-JSONOPTS-001"
 
-[<CliAnalyzer("JsonSerializerOptionsAnalyzer",
-              "Scans code for inline usage of JsonSerializerOptions",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/JsonSerializerOptionsAnalyzer.html")>]
-let jsonSerializerOptionsAnalyzer : Analyzer<CliContext> =
-    fun ctx ->
-        async {
-            let state = ResizeArray<range> ()
+let analyze (typedTree : FSharpImplementationFileContents) =
+    let state = ResizeArray<range> ()
 
-            let namesToWarnAbount =
-                set
-                    [
-                        "System.Text.Json.JsonSerializer.Deserialize"
-                        "System.Text.Json.JsonSerializer.DeserializeAsync"
-                        "System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable"
-                        "System.Text.Json.JsonSerializer.Serialize"
-                        "System.Text.Json.JsonSerializer.SerializeAsync"
-                        "System.Text.Json.JsonSerializer.SerializeToDocument"
-                        "System.Text.Json.JsonSerializer.SerializeToElement"
-                        "System.Text.Json.JsonSerializer.SerializeToNode"
-                        "System.Text.Json.JsonSerializer.SerializeToUtf8Bytes"
-                    ]
+    let namesToWarnAbount =
+        set
+            [
+                "System.Text.Json.JsonSerializer.Deserialize"
+                "System.Text.Json.JsonSerializer.DeserializeAsync"
+                "System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable"
+                "System.Text.Json.JsonSerializer.Serialize"
+                "System.Text.Json.JsonSerializer.SerializeAsync"
+                "System.Text.Json.JsonSerializer.SerializeToDocument"
+                "System.Text.Json.JsonSerializer.SerializeToElement"
+                "System.Text.Json.JsonSerializer.SerializeToNode"
+                "System.Text.Json.JsonSerializer.SerializeToUtf8Bytes"
+            ]
 
-            let walker =
-                { new TypedTreeCollectorBase() with
-                    override _.WalkCall
-                        _
-                        (m : FSharpMemberOrFunctionOrValue)
-                        _
-                        _
-                        (args : FSharpExpr list)
-                        (range : range)
-                        =
-                        let name = String.Join (".", m.DeclaringEntity.Value.FullName, m.DisplayName)
-                        let assemblyName = "System.Text.Json"
+    let walker =
+        { new TypedTreeCollectorBase() with
+            override _.WalkCall _ (m : FSharpMemberOrFunctionOrValue) _ _ (args : FSharpExpr list) (range : range) =
+                let name = String.Join (".", m.DeclaringEntity.Value.FullName, m.DisplayName)
+                let assemblyName = "System.Text.Json"
 
-                        let containsSerOptsCtorCall =
-                            args
-                            |> List.exists (
-                                function
-                                | NewObject (objType, _, _) when
-                                    objType.FullName = "System.Text.Json.JsonSerializerOptions"
-                                    && objType.Assembly.SimpleName = assemblyName
-                                    ->
-                                    true
-                                | _ -> false
-                            )
+                let containsSerOptsCtorCall =
+                    args
+                    |> List.exists (
+                        function
+                        | NewObject (objType, _, _) when
+                            objType.FullName = "System.Text.Json.JsonSerializerOptions"
+                            && objType.Assembly.SimpleName = assemblyName
+                            ->
+                            true
+                        | _ -> false
+                    )
 
-                        if
-                            m.Assembly.SimpleName = assemblyName
-                            && Set.contains name namesToWarnAbount
-                            && containsSerOptsCtorCall
-                        then
-                            state.Add range
-                }
-
-            ctx.TypedTree |> Option.iter (walkTast walker)
-
-            return
-                state
-                |> Seq.map (fun r ->
-                    {
-                        Type = "JsonSerializerOptions analyzer"
-                        Message = "JsonSerializerOptions instances should be cached."
-                        Code = Code
-                        Severity = Warning
-                        Range = r
-                        Fixes = []
-                    }
-                )
-                |> Seq.toList
+                if
+                    m.Assembly.SimpleName = assemblyName
+                    && Set.contains name namesToWarnAbount
+                    && containsSerOptsCtorCall
+                then
+                    state.Add range
         }
+
+    walkTast walker typedTree
+
+    state
+    |> Seq.map (fun r ->
+        {
+            Type = "JsonSerializerOptions analyzer"
+            Message = "JsonSerializerOptions instances should be cached."
+            Code = Code
+            Severity = Warning
+            Range = r
+            Fixes = []
+        }
+    )
+    |> Seq.toList
+
+[<Literal>]
+let Name = "JsonSerializerOptionsAnalyzer"
+
+[<Literal>]
+let ShortDescription = "Scans code for inline usage of JsonSerializerOptions"
+
+[<Literal>]
+let HelpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/JsonSerializerOptionsAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+let jsonSerializerOptionsCliAnalyzer : Analyzer<CliContext> =
+    fun ctx -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+let jsonSerializerOptionsEditorAnalyzer : Analyzer<EditorContext> =
+    fun ctx -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }

--- a/src/FSharp.Analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.fs
+++ b/src/FSharp.Analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.fs
@@ -10,74 +10,80 @@ open FSharp.Compiler.Text
 [<Literal>]
 let Code = "GRA-LOGARGFUNCFULLAPP-001"
 
-[<CliAnalyzer("LoggingArgFuncNotFullyAppliedAnalyzer",
-              "Checks if function arguments to ILogging methods are fully applied",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.html")>]
-let loggingArgFuncNotFullyAppliedAnalyzer : Analyzer<CliContext> =
-    fun (ctx : CliContext) ->
-        async {
-            let state = ResizeArray<range> ()
+let analyze (typedTree : FSharpImplementationFileContents) =
+    let state = ResizeArray<range> ()
 
-            let namesToWarnAbout =
-                set
-                    [
-                        "Microsoft.Extensions.Logging.LoggerExtensions.Log"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogCritical"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogDebug"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogError"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogInformation"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogTrace"
-                        "Microsoft.Extensions.Logging.LoggerExtensions.LogWarning"
-                    ]
+    let namesToWarnAbout =
+        set
+            [
+                "Microsoft.Extensions.Logging.LoggerExtensions.Log"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogCritical"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogDebug"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogError"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogInformation"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogTrace"
+                "Microsoft.Extensions.Logging.LoggerExtensions.LogWarning"
+            ]
 
-            let walker =
-                { new TypedTreeCollectorBase() with
-                    override _.WalkCall
-                        _
-                        (m : FSharpMemberOrFunctionOrValue)
-                        _
-                        _
-                        (args : FSharpExpr list)
-                        (range : range)
-                        =
-                        let name = String.Join (".", m.DeclaringEntity.Value.FullName, m.DisplayName)
-                        let assemblyName = "Microsoft.Extensions.Logging.Abstractions"
+    let walker =
+        { new TypedTreeCollectorBase() with
+            override _.WalkCall _ (m : FSharpMemberOrFunctionOrValue) _ _ (args : FSharpExpr list) (range : range) =
+                let name = String.Join (".", m.DeclaringEntity.Value.FullName, m.DisplayName)
+                let assemblyName = "Microsoft.Extensions.Logging.Abstractions"
 
-                        let argsContainPartiallyAppliedFunc =
-                            args
+                let argsContainPartiallyAppliedFunc =
+                    args
+                    |> List.exists (
+                        function
+                        | NewArray (_type, exprs) ->
+                            exprs
                             |> List.exists (
                                 function
-                                | NewArray (_type, exprs) ->
-                                    exprs
-                                    |> List.exists (
-                                        function
-                                        | Coerce (_type, expr) -> expr.Type.IsFunctionType
-                                        | _ -> false
-                                    )
+                                | Coerce (_type, expr) -> expr.Type.IsFunctionType
                                 | _ -> false
                             )
+                        | _ -> false
+                    )
 
-                        if
-                            m.Assembly.SimpleName = assemblyName
-                            && Set.contains name namesToWarnAbout
-                            && argsContainPartiallyAppliedFunc
-                        then
-                            state.Add range
-                }
-
-            ctx.TypedTree |> Option.iter (walkTast walker)
-
-            return
-                [
-                    for range in state do
-                        {
-                            Type = "LoggingArgFuncNotFullyAppliedAnalyzer"
-                            Message =
-                                "You have passed a function as one of the display arguments to ILogger.Log{Warning, Error, ...}. You have probably not applied this function fully."
-                            Code = Code
-                            Severity = Warning
-                            Range = range
-                            Fixes = []
-                        }
-                ]
+                if
+                    m.Assembly.SimpleName = assemblyName
+                    && Set.contains name namesToWarnAbout
+                    && argsContainPartiallyAppliedFunc
+                then
+                    state.Add range
         }
+
+    walkTast walker typedTree
+
+    [
+        for range in state do
+            {
+                Type = "LoggingArgFuncNotFullyAppliedAnalyzer"
+                Message =
+                    "You have passed a function as one of the display arguments to ILogger.Log{Warning, Error, ...}. You have probably not applied this function fully."
+                Code = Code
+                Severity = Warning
+                Range = range
+                Fixes = []
+            }
+    ]
+
+
+[<Literal>]
+let Name = "LoggingArgFuncNotFullyAppliedAnalyzer"
+
+[<Literal>]
+let ShortDescription =
+    "Checks if function arguments to ILogging methods are fully applied"
+
+[<Literal>]
+let HelpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+let loggingArgFuncNotFullyAppliedCliAnalyzer : Analyzer<CliContext> =
+    fun (ctx : CliContext) -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+let loggingArgFuncNotFullyAppliedEditorAnalyzer : Analyzer<EditorContext> =
+    fun (ctx : EditorContext) -> async { return ctx.TypedTree |> Option.map analyze |> Option.defaultValue [] }

--- a/src/FSharp.Analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.fsi
+++ b/src/FSharp.Analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.fsi
@@ -5,7 +5,17 @@ open FSharp.Analyzers.SDK
 [<Literal>]
 val Code : string = "GRA-LOGARGFUNCFULLAPP-001"
 
-[<CliAnalyzer("LoggingArgFuncNotFullyAppliedAnalyzer",
-              "Checks if function arguments to ILogging methods are fully applied",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.html")>]
-val loggingArgFuncNotFullyAppliedAnalyzer : ctx : CliContext -> Async<Message list>
+[<Literal>]
+val Name : string = "LoggingArgFuncNotFullyAppliedAnalyzer"
+
+[<Literal>]
+val ShortDescription : string = "Checks if function arguments to ILogging methods are fully applied"
+
+[<Literal>]
+val HelpUri : string = "https://g-research.github.io/fsharp-analyzers/analyzers/LoggingArgFuncNotFullyAppliedAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val loggingArgFuncNotFullyAppliedCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val loggingArgFuncNotFullyAppliedEditorAnalyzer : ctx : EditorContext -> Async<Message list>

--- a/src/FSharp.Analyzers/PartialAppAnalyzer.fs
+++ b/src/FSharp.Analyzers/PartialAppAnalyzer.fs
@@ -379,13 +379,21 @@ let analyze parseTree (checkFileResults : FSharpCheckFileResults) =
 
     msgs
 
-[<CliAnalyzer("PartialAppAnalyzer",
-              "Warns when partial application is being used.",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/PartialAppAnalyzer.html")>]
+[<Literal>]
+let name = "PartialAppAnalyzer"
+
+[<Literal>]
+let shortDescription = "Warns when partial application is being used."
+
+[<Literal>]
+let helpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/PartialAppAnalyzer.html"
+
+[<CliAnalyzer(name, shortDescription, helpUri)>]
 let partialAppCliAnalyzer : Analyzer<CliContext> =
     fun context -> async { return analyze context.ParseFileResults.ParseTree context.CheckFileResults }
 
-[<EditorAnalyzer "PartialAppAnalyzer">]
+[<EditorAnalyzer(name, shortDescription, helpUri)>]
 let partialAppEditorAnalyzer : Analyzer<EditorContext> =
     fun context ->
         async {

--- a/src/FSharp.Analyzers/StringAnalyzer.fs
+++ b/src/FSharp.Analyzers/StringAnalyzer.fs
@@ -14,6 +14,10 @@ let StringStartsWithCode = "GRA-STRING-002"
 [<Literal>]
 let StringIndexOfCode = "GRA-STRING-003"
 
+[<Literal>]
+let HelpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html"
+
 let tryGetFullName (e : FSharpExpr) =
     if e.Type.ErasedType.HasTypeDefinition then
         e.Type.ErasedType.TypeDefinition.TryGetFullName ()
@@ -70,72 +74,88 @@ let invalidStringFunctionUseAnalyzer
     )
     |> Seq.toList
 
-[<CliAnalyzer("String.EndsWith Analyzer",
-              "Verifies the correct usage of System.String.EndsWith",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-let endsWithAnalyzer (ctx : CliContext) : Async<Message list> =
-    async {
-        match ctx.TypedTree with
-        | None -> return List.empty
-        | Some typedTree ->
+let endsWithAnalyze (typedTree : FSharpImplementationFileContents) =
+    invalidStringFunctionUseAnalyzer
+        "EndsWith"
+        StringEndsWithCode
+        "The usage of String.EndsWith with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
+        Warning
+        typedTree
+        (fun (args : FSharpExpr list) ->
+            match args with
+            | [ StringExpr ] -> true
+            | _ -> false
+        )
 
-        return
-            invalidStringFunctionUseAnalyzer
-                "EndsWith"
-                StringEndsWithCode
-                "The usage of String.EndsWith with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
-                Warning
-                typedTree
-                (fun (args : FSharpExpr list) ->
-                    match args with
-                    | [ StringExpr ] -> true
-                    | _ -> false
-                )
-    }
+[<Literal>]
+let StringEndsWithName = "String.EndsWith Analyzer"
 
-[<CliAnalyzer("String.StartsWith Analyzer",
-              "Verifies the correct usage of System.String.StartsWith",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-let startsWithAnalyzer (ctx : CliContext) : Async<Message list> =
-    async {
-        match ctx.TypedTree with
-        | None -> return List.empty
-        | Some typedTree ->
-            return
-                invalidStringFunctionUseAnalyzer
-                    "StartsWith"
-                    StringStartsWithCode
-                    "The usage of String.StartsWith with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
-                    Warning
-                    typedTree
-                    (fun (args : FSharpExpr list) ->
-                        match args with
-                        | [ StringExpr ] -> true
-                        | _ -> false
-                    )
-    }
+[<Literal>]
+let StringEndsWithShortDescription =
+    "Verifies the correct usage of System.String.EndsWith"
 
-[<CliAnalyzer("String.IndexOf Analyzer",
-              "Verifies the correct usage of System.String.IndexOf",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-let indexOfAnalyzer (ctx : CliContext) : Async<Message list> =
-    async {
-        match ctx.TypedTree with
-        | None -> return List.empty
-        | Some typedTree ->
+[<CliAnalyzer(StringEndsWithName, StringEndsWithShortDescription, HelpUri)>]
+let endsWithCliAnalyzer (ctx : CliContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map endsWithAnalyze |> Option.defaultValue [] }
 
-        return
-            invalidStringFunctionUseAnalyzer
-                "IndexOf"
-                StringIndexOfCode
-                "The usage of String.IndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
-                Warning
-                typedTree
-                (fun args ->
-                    match args with
-                    | [ StringExpr ]
-                    | [ StringExpr ; IntExpr ]
-                    | [ StringExpr ; IntExpr ; IntExpr ] -> true
-                    | _ -> false
-                )
-    }
+[<EditorAnalyzer(StringEndsWithName, StringEndsWithShortDescription, HelpUri)>]
+let endsWithEditorAnalyzer (ctx : EditorContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map endsWithAnalyze |> Option.defaultValue [] }
+
+let startsWithAnalyze (typedTree : FSharpImplementationFileContents) =
+    invalidStringFunctionUseAnalyzer
+        "StartsWith"
+        StringStartsWithCode
+        "The usage of String.StartsWith with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
+        Warning
+        typedTree
+        (fun (args : FSharpExpr list) ->
+            match args with
+            | [ StringExpr ] -> true
+            | _ -> false
+        )
+
+[<Literal>]
+let StringStartsWithName = "String.StartsWith Analyzer"
+
+[<Literal>]
+let StringStartsWithShortDescription =
+    "Verifies the correct usage of System.String.StartsWith"
+
+[<CliAnalyzer(StringStartsWithName, StringStartsWithShortDescription, HelpUri)>]
+let startsWithCliAnalyzer (ctx : CliContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map startsWithAnalyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(StringStartsWithName, StringStartsWithShortDescription, HelpUri)>]
+let startsWithEditorAnalyzer (ctx : EditorContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map startsWithAnalyze |> Option.defaultValue [] }
+
+let indexOfAnalyze (typedTree : FSharpImplementationFileContents) =
+    invalidStringFunctionUseAnalyzer
+        "IndexOf"
+        StringIndexOfCode
+        "The usage of String.IndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
+        Warning
+        typedTree
+        (fun args ->
+            match args with
+            | [ StringExpr ]
+            | [ StringExpr ; IntExpr ]
+            | [ StringExpr ; IntExpr ; IntExpr ] -> true
+            | _ -> false
+        )
+
+[<Literal>]
+let StringIndexOfName = "String.IndexOf Analyzer"
+
+[<Literal>]
+let StringIndexOfShortDescription =
+    "Verifies the correct usage of System.String.IndexOf"
+
+[<CliAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
+let indexOfCliAnalyzer (ctx : CliContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map indexOfAnalyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
+let indexOfEditorAnalyzer (ctx : EditorContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map indexOfAnalyze |> Option.defaultValue [] }

--- a/src/FSharp.Analyzers/StringAnalyzer.fsi
+++ b/src/FSharp.Analyzers/StringAnalyzer.fsi
@@ -3,25 +3,49 @@ module GR.FSharp.Analyzers.StringAnalyzer
 open FSharp.Analyzers.SDK
 
 [<Literal>]
+val HelpUri : string = "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html"
+
+[<Literal>]
 val StringEndsWithCode : string = "GRA-STRING-001"
+
+[<Literal>]
+val StringEndsWithName : string = "String.EndsWith Analyzer"
+
+[<Literal>]
+val StringEndsWithShortDescription : string = "Verifies the correct usage of System.String.EndsWith"
+
+[<CliAnalyzer(StringEndsWithName, StringEndsWithShortDescription, HelpUri)>]
+val endsWithCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(StringEndsWithName, StringEndsWithShortDescription, HelpUri)>]
+val endsWithEditorAnalyzer : ctx : EditorContext -> Async<Message list>
 
 [<Literal>]
 val StringStartsWithCode : string = "GRA-STRING-002"
 
 [<Literal>]
+val StringStartsWithName : string = "String.StartsWith Analyzer"
+
+[<Literal>]
+val StringStartsWithShortDescription : string = "Verifies the correct usage of System.String.StartsWith"
+
+[<CliAnalyzer(StringStartsWithName, StringStartsWithShortDescription, HelpUri)>]
+val startsWithCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(StringStartsWithName, StringStartsWithShortDescription, HelpUri)>]
+val startsWithEditorAnalyzer : ctx : EditorContext -> Async<Message list>
+
+[<Literal>]
 val StringIndexOfCode : string = "GRA-STRING-003"
 
-[<CliAnalyzer("String.EndsWith Analyzer",
-              "Verifies the correct usage of System.String.EndsWith",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-val endsWithAnalyzer : ctx : CliContext -> Async<Message list>
+[<Literal>]
+val StringIndexOfName : string = "String.IndexOf Analyzer"
 
-[<CliAnalyzer("String.StartsWith Analyzer",
-              "Verifies the correct usage of System.String.StartsWith",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-val startsWithAnalyzer : ctx : CliContext -> Async<Message list>
+[<Literal>]
+val StringIndexOfShortDescription : string = "Verifies the correct usage of System.String.IndexOf"
 
-[<CliAnalyzer("String.IndexOf Analyzer",
-              "Verifies the correct usage of System.String.IndexOf",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html")>]
-val indexOfAnalyzer : ctx : CliContext -> Async<Message list>
+[<CliAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
+val indexOfCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
+val indexOfEditorAnalyzer : ctx : EditorContext -> Async<Message list>

--- a/src/FSharp.Analyzers/TypeAnnotateStringFunctionAnalyzer.fs
+++ b/src/FSharp.Analyzers/TypeAnnotateStringFunctionAnalyzer.fs
@@ -41,81 +41,101 @@ let (|StringFunctionExpr|_|) =
         |> Option.bind (fun ident -> if ident.idText = "string" then Some () else None)
     | _ -> None
 
-[<CliAnalyzer("TypeAnnotateStringFunctionAnalyzer",
-              "Checks if the `string` function call is type annotated.",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/TypeAnnotateStringFunctionAnalyzer.html")>]
-let typeAnnotateStringFunctionsAnalyzer : Analyzer<CliContext> =
+let analyze (sourceText : ISourceText) (parseTree : ParsedInput) (typedTree : FSharpImplementationFileContents) =
+    let messages = ResizeArray<Message> ()
+
+    let tryFindSynExprApp (m : range) =
+        let visitor =
+            { new SyntaxVisitorBase<StringApplicationResult>() with
+                override x.VisitExpr (path, traverseSynExpr, defaultTraverse, synExpr) =
+                    if not (Range.equals synExpr.Range m) then
+                        defaultTraverse synExpr
+                    else
+                        match synExpr with
+                        // in this case expression was probably piped into the string function.
+                        | StringFunctionExpr ->
+                            match path with
+                            | SyntaxNode.SynExpr (SynExpr.TypeApp _) :: _ -> Some StringApplicationResult.TypeArgument
+                            | _ -> Some StringApplicationResult.NoTypeArgument
+
+                        | SynExpr.App (funcExpr = StringFunctionExpr) -> Some StringApplicationResult.NoTypeArgument
+
+                        | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = StringFunctionExpr)) ->
+                            Some StringApplicationResult.TypeArgument
+                        | e ->
+                            let source = sourceText.GetContentAt e.Range
+                            Some (StringApplicationResult.Unsure source)
+            }
+
+        SyntaxTraversal.Traverse (m.Start, parseTree, visitor)
+
+    let tastCollector =
+        { new TypedTreeCollectorBase() with
+            override x.WalkCall
+                _
+                (mfv : FSharpMemberOrFunctionOrValue)
+                objExprTypeArgs
+                memberOrFuncTypeArgs
+                (args : FSharpExpr list)
+                (m : range)
+                =
+                if mfv.FullName = "Microsoft.FSharp.Core.Operators.string" && args.Length = 1 then
+                    match tryFindSynExprApp m with
+                    | Some (StringApplicationResult.Unsure sourceCode) ->
+#if DEBUG
+                        printfn $"Could map %A{m} to a string application, source:\n%s{sourceCode}"
+#else
+                        ignore sourceCode
+#endif
+                    | Some StringApplicationResult.NoTypeArgument ->
+                        messages.Add
+                            {
+                                Type = "TypeAnnotateStringFunctionsAnalyzer"
+                                Message = "Please annotate your type when using the `string` function."
+                                Code = "GRA-TYPE-ANNOTATE-001"
+                                Severity = Severity.Warning
+                                Range = m
+                                Fixes = []
+                            }
+                    | Some StringApplicationResult.TypeArgument -> ()
+                    | None ->
+#if DEBUG
+                        printfn $"Could not find application for %A{m}"
+#else
+                        ()
+#endif
+        }
+
+
+    walkTast tastCollector typedTree
+    Seq.toList messages
+
+[<Literal>]
+let Name = "TypeAnnotateStringFunctionAnalyzer"
+
+[<Literal>]
+let ShortDescription = "Checks if the `string` function call is type annotated."
+
+[<Literal>]
+let HelpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/TypeAnnotateStringFunctionAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+let typeAnnotateStringFunctionsCliAnalyzer : Analyzer<CliContext> =
     fun (ctx : CliContext) ->
         async {
-            let messages = ResizeArray<Message> ()
+            return
+                ctx.TypedTree
+                |> Option.map (analyze ctx.SourceText ctx.ParseFileResults.ParseTree)
+                |> Option.defaultValue []
+        }
 
-            let tryFindSynExprApp (m : range) =
-                let visitor =
-                    { new SyntaxVisitorBase<StringApplicationResult>() with
-                        override x.VisitExpr (path, traverseSynExpr, defaultTraverse, synExpr) =
-                            if not (Range.equals synExpr.Range m) then
-                                defaultTraverse synExpr
-                            else
-                                match synExpr with
-                                // in this case expression was probably piped into the string function.
-                                | StringFunctionExpr ->
-                                    match path with
-                                    | SyntaxNode.SynExpr (SynExpr.TypeApp _) :: _ ->
-                                        Some StringApplicationResult.TypeArgument
-                                    | _ -> Some StringApplicationResult.NoTypeArgument
-
-                                | SynExpr.App (funcExpr = StringFunctionExpr) ->
-                                    Some StringApplicationResult.NoTypeArgument
-
-                                | SynExpr.App (funcExpr = SynExpr.TypeApp (expr = StringFunctionExpr)) ->
-                                    Some StringApplicationResult.TypeArgument
-                                | e ->
-                                    let source = ctx.SourceText.GetContentAt e.Range
-                                    Some (StringApplicationResult.Unsure source)
-                    }
-
-                SyntaxTraversal.Traverse (m.Start, ctx.ParseFileResults.ParseTree, visitor)
-
-            let tastCollector =
-                { new TypedTreeCollectorBase() with
-                    override x.WalkCall
-                        _
-                        (mfv : FSharpMemberOrFunctionOrValue)
-                        objExprTypeArgs
-                        memberOrFuncTypeArgs
-                        (args : FSharpExpr list)
-                        (m : range)
-                        =
-                        if mfv.FullName = "Microsoft.FSharp.Core.Operators.string" && args.Length = 1 then
-                            match tryFindSynExprApp m with
-                            | Some (StringApplicationResult.Unsure sourceCode) ->
-#if DEBUG
-                                printfn $"Could map %A{m} to a string application, source:\n%s{sourceCode}"
-#else
-                                ignore sourceCode
-#endif
-                            | Some StringApplicationResult.NoTypeArgument ->
-                                messages.Add
-                                    {
-                                        Type = "TypeAnnotateStringFunctionsAnalyzer"
-                                        Message = "Please annotate your type when using the `string` function."
-                                        Code = "GRA-TYPE-ANNOTATE-001"
-                                        Severity = Severity.Warning
-                                        Range = m
-                                        Fixes = []
-                                    }
-                            | Some StringApplicationResult.TypeArgument -> ()
-                            | None ->
-#if DEBUG
-                                printfn $"Could not find application for %A{m}"
-#else
-                                ()
-#endif
-                }
-
-            match ctx.TypedTree with
-            | None -> return []
-            | Some typedTree ->
-                walkTast tastCollector typedTree
-                return Seq.toList messages
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+let typeAnnotateStringFunctionsEditorAnalyzer : Analyzer<EditorContext> =
+    fun (ctx : EditorContext) ->
+        async {
+            return
+                ctx.TypedTree
+                |> Option.map (analyze ctx.SourceText ctx.ParseFileResults.ParseTree)
+                |> Option.defaultValue []
         }

--- a/src/FSharp.Analyzers/TypedInterpolatedStringsAnalyzer.fs
+++ b/src/FSharp.Analyzers/TypedInterpolatedStringsAnalyzer.fs
@@ -5,6 +5,7 @@ open System.Text.RegularExpressions
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.ASTCollecting
 open FSharp.Analyzers.SDK.TASTCollecting
+open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 
@@ -15,66 +16,82 @@ let Code = "GRA-INTERPOLATED-001"
 let specifierRegex =
     Regex (@"\%(\+|\-)?\d*\.?\d*(b|s|c|d|i|u|x|X|o|B|e|E|f|F|g|G|M|O|A)$")
 
-[<CliAnalyzer("TypedInterpolatedStringsAnalyzer",
-              "Warns about missing type specifiers in interpolated strings",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/TypedInterpolatedStringsAnalyzer.html")>]
-let typedInterpolatedStringsAnalyzer : Analyzer<CliContext> =
+let analyze (parseTree : ParsedInput) (typedTree : FSharpImplementationFileContents) =
+    let messages = ResizeArray<Message> ()
+    // Formattable strings needs to be skipped https://learn.microsoft.com/en-us/dotnet/api/system.formattablestring?view=net-8.0
+    let formattableStrings = HashSet Range.comparer
+
+    let tastWalker =
+        { new TypedTreeCollectorBase() with
+            override _.WalkCall objExprOpt memberOrFunc objExprTypeArgs memberOrFuncTypeArgs argExprs exprRange =
+                if
+                    memberOrFunc.FullName = "System.Runtime.CompilerServices.FormattableStringFactory.Create"
+                    && argExprs.Length = 2
+                    && argExprs.[0].Type.ErasedType.BasicQualifiedName = "System.String"
+                then
+                    formattableStrings.Add argExprs.[0].Range |> ignore
+        }
+
+    walkTast tastWalker typedTree
+
+    let walker =
+        { new SyntaxCollectorBase() with
+            override x.WalkExpr (_, expr : SynExpr) =
+                match expr with
+                | SynExpr.InterpolatedString (contents = contents) when not (formattableStrings.Contains expr.Range) ->
+                    contents
+                    |> List.pairwise
+                    |> List.iter (fun (p1, p2) ->
+                        match p1, p2 with
+                        | SynInterpolatedStringPart.String (value = s),
+                          SynInterpolatedStringPart.FillExpr (fillExpr = e) ->
+                            if not (isNull s) && not (specifierRegex.IsMatch s) then
+                                messages.Add
+                                    {
+                                        Type = "TypedInterpolatedStringsAnalyzer"
+                                        Message =
+                                            "Interpolated hole expression without format detected. Use prefix with the correct % to enforce type safety."
+                                        Code = Code
+                                        Severity = Warning
+                                        Range = e.Range
+                                        Fixes = []
+                                    }
+                        | _ -> ()
+                    )
+                | _ -> ()
+        }
+
+    walkAst walker parseTree
+
+    Seq.toList messages
+
+
+[<Literal>]
+let Name = "TypedInterpolatedStringsAnalyzer"
+
+[<Literal>]
+let ShortDescription = "Warns about missing type specifiers in interpolated strings"
+
+[<Literal>]
+let helpUri =
+    "https://g-research.github.io/fsharp-analyzers/analyzers/TypedInterpolatedStringsAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, helpUri)>]
+let typedInterpolatedStringsCliAnalyzer : Analyzer<CliContext> =
     fun (ctx : CliContext) ->
         async {
-            let messages = ResizeArray<Message> ()
-            // Formattable strings needs to be skipped https://learn.microsoft.com/en-us/dotnet/api/system.formattablestring?view=net-8.0
-            let formattableStrings = HashSet Range.comparer
+            return
+                ctx.TypedTree
+                |> Option.map (analyze ctx.ParseFileResults.ParseTree)
+                |> Option.defaultValue []
+        }
 
-            let tastWalker =
-                { new TypedTreeCollectorBase() with
-                    override _.WalkCall
-                        objExprOpt
-                        memberOrFunc
-                        objExprTypeArgs
-                        memberOrFuncTypeArgs
-                        argExprs
-                        exprRange
-                        =
-                        if
-                            memberOrFunc.FullName = "System.Runtime.CompilerServices.FormattableStringFactory.Create"
-                            && argExprs.Length = 2
-                            && argExprs.[0].Type.ErasedType.BasicQualifiedName = "System.String"
-                        then
-                            formattableStrings.Add argExprs.[0].Range |> ignore
-                }
-
-            Option.iter (walkTast tastWalker) ctx.TypedTree
-
-            let walker =
-                { new SyntaxCollectorBase() with
-                    override x.WalkExpr (_, expr : SynExpr) =
-                        match expr with
-                        | SynExpr.InterpolatedString (contents = contents) when
-                            not (formattableStrings.Contains expr.Range)
-                            ->
-                            contents
-                            |> List.pairwise
-                            |> List.iter (fun (p1, p2) ->
-                                match p1, p2 with
-                                | SynInterpolatedStringPart.String (value = s),
-                                  SynInterpolatedStringPart.FillExpr (fillExpr = e) ->
-                                    if not (isNull s) && not (specifierRegex.IsMatch s) then
-                                        messages.Add
-                                            {
-                                                Type = "TypedInterpolatedStringsAnalyzer"
-                                                Message =
-                                                    "Interpolated hole expression without format detected. Use prefix with the correct % to enforce type safety."
-                                                Code = Code
-                                                Severity = Warning
-                                                Range = e.Range
-                                                Fixes = []
-                                            }
-                                | _ -> ()
-                            )
-                        | _ -> ()
-                }
-
-            walkAst walker ctx.ParseFileResults.ParseTree
-
-            return Seq.toList messages
+[<EditorAnalyzer(Name, ShortDescription, helpUri)>]
+let typedInterpolatedStringsEditorAnalyzer : Analyzer<EditorContext> =
+    fun (ctx : EditorContext) ->
+        async {
+            return
+                ctx.TypedTree
+                |> Option.map (analyze ctx.ParseFileResults.ParseTree)
+                |> Option.defaultValue []
         }

--- a/src/FSharp.Analyzers/VirtualCallAnalyzer.fsi
+++ b/src/FSharp.Analyzers/VirtualCallAnalyzer.fsi
@@ -5,7 +5,17 @@ open FSharp.Analyzers.SDK
 [<Literal>]
 val Code : string = "GRA-VIRTUALCALL-001"
 
-[<CliAnalyzer("VirtualCall Analyzer",
-              "Checks if calls of Seq functions can be replaced with functions from the collection modules",
-              "https://g-research.github.io/fsharp-analyzers/analyzers/VirtualCallAnalyzer.html")>]
-val virtualCallAnalyzer : ctx : CliContext -> Async<Message list>
+[<Literal>]
+val Name : string = "VirtualCall Analyzer"
+
+[<Literal>]
+val ShortDescription : string = "Checks if calls of Seq functions can be replaced with functions from the collection modules"
+
+[<Literal>]
+val HelpUri : string = "https://g-research.github.io/fsharp-analyzers/analyzers/VirtualCallAnalyzer.html"
+
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val virtualCallCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val virtualCallEditorAnalyzer : ctx : EditorContext -> Async<Message list>

--- a/tests/FSharp.Analyzers.Tests/ImmutableCollectionEqualityAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/ImmutableCollectionEqualityAnalyzerTests.fs
@@ -31,7 +31,7 @@ let ImmutableCollectionEqualityAnalyzerTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> ImmutableCollectionEqualityAnalyzer.immutableCollectionEqualityAnalyzer
+            |> ImmutableCollectionEqualityAnalyzer.immutableCollectionEqualityCliAnalyzer
 
         do! assertExpected fileName messages
     }
@@ -50,7 +50,7 @@ let NegativeTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> ImmutableCollectionEqualityAnalyzer.immutableCollectionEqualityAnalyzer
+            |> ImmutableCollectionEqualityAnalyzer.immutableCollectionEqualityCliAnalyzer
 
         Assert.That (messages, Is.Empty)
     }

--- a/tests/FSharp.Analyzers.Tests/JsonSerializerOptionsAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/JsonSerializerOptionsAnalyzerTests.fs
@@ -42,7 +42,7 @@ module JsonSerializerOptionsAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> JsonSerializerOptionsAnalyzer.jsonSerializerOptionsAnalyzer
+                |> JsonSerializerOptionsAnalyzer.jsonSerializerOptionsCliAnalyzer
 
             do! assertExpected fileName messages
         }

--- a/tests/FSharp.Analyzers.Tests/LoggingArgFuncNotFullyAppliedAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/LoggingArgFuncNotFullyAppliedAnalyzerTests.fs
@@ -46,7 +46,7 @@ module LoggingArgFuncNotFullyAppliedAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> LoggingArgFuncNotFullyAppliedAnalyzer.loggingArgFuncNotFullyAppliedAnalyzer
+                |> LoggingArgFuncNotFullyAppliedAnalyzer.loggingArgFuncNotFullyAppliedCliAnalyzer
 
             do! assertExpected fileName messages
         }
@@ -65,7 +65,7 @@ module LoggingArgFuncNotFullyAppliedAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> LoggingArgFuncNotFullyAppliedAnalyzer.loggingArgFuncNotFullyAppliedAnalyzer
+                |> LoggingArgFuncNotFullyAppliedAnalyzer.loggingArgFuncNotFullyAppliedCliAnalyzer
 
             Assert.That (messages, Is.Empty)
         }

--- a/tests/FSharp.Analyzers.Tests/StringAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/StringAnalyzerTests.fs
@@ -33,9 +33,9 @@ let findStringAnalyzerFor (fileName : string) =
     |> Array.skip 1
     |> Array.head
     |> function
-        | "endswith" -> StringAnalyzer.endsWithAnalyzer
-        | "startswith" -> StringAnalyzer.startsWithAnalyzer
-        | "indexof" -> StringAnalyzer.indexOfAnalyzer
+        | "endswith" -> StringAnalyzer.endsWithCliAnalyzer
+        | "startswith" -> StringAnalyzer.startsWithCliAnalyzer
+        | "indexof" -> StringAnalyzer.indexOfCliAnalyzer
         | unknown -> failwithf $"Unknown subfolder \"%s{unknown}\", please configure analyzer"
 
 [<TestCaseSource(typeof<TestCases>)>]

--- a/tests/FSharp.Analyzers.Tests/TypeAnnotateStringFunctionAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/TypeAnnotateStringFunctionAnalyzerTests.fs
@@ -32,7 +32,7 @@ let TypeAnnotateStringFunctionsTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> TypeAnnotateStringFunctionAnalyzer.typeAnnotateStringFunctionsAnalyzer
+            |> TypeAnnotateStringFunctionAnalyzer.typeAnnotateStringFunctionsCliAnalyzer
 
         do! assertExpected fileName messages
     }
@@ -51,7 +51,7 @@ let NegativeTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> TypeAnnotateStringFunctionAnalyzer.typeAnnotateStringFunctionsAnalyzer
+            |> TypeAnnotateStringFunctionAnalyzer.typeAnnotateStringFunctionsCliAnalyzer
 
         Assert.That (messages, Is.Empty)
     }

--- a/tests/FSharp.Analyzers.Tests/TypedInterpolatedStringsAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/TypedInterpolatedStringsAnalyzerTests.fs
@@ -31,7 +31,7 @@ let TypedInterpolatedStringsAnalyzerTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> TypedInterpolatedStringsAnalyzer.typedInterpolatedStringsAnalyzer
+            |> TypedInterpolatedStringsAnalyzer.typedInterpolatedStringsCliAnalyzer
 
         do! assertExpected fileName messages
     }
@@ -50,7 +50,7 @@ let NegativeTests (fileName : string) =
         let! messages =
             File.ReadAllText fileName
             |> getContext projectOptions
-            |> TypedInterpolatedStringsAnalyzer.typedInterpolatedStringsAnalyzer
+            |> TypedInterpolatedStringsAnalyzer.typedInterpolatedStringsCliAnalyzer
 
         Assert.That (messages, Is.Empty)
     }

--- a/tests/FSharp.Analyzers.Tests/UnionCaseAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/UnionCaseAnalyzerTests.fs
@@ -34,7 +34,7 @@ module UnionCaseAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> UnionCaseAnalyzer.unionCaseAnalyzer
+                |> UnionCaseAnalyzer.unionCaseCliAnalyzer
 
             do! assertExpected fileName messages
         }
@@ -53,7 +53,7 @@ module UnionCaseAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> UnionCaseAnalyzer.unionCaseAnalyzer
+                |> UnionCaseAnalyzer.unionCaseCliAnalyzer
 
             Assert.That (messages, Is.Empty)
         }

--- a/tests/FSharp.Analyzers.Tests/VirtualCallAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/VirtualCallAnalyzerTests.fs
@@ -34,7 +34,7 @@ module VirtualCallAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> VirtualCallAnalyzer.virtualCallAnalyzer
+                |> VirtualCallAnalyzer.virtualCallCliAnalyzer
 
             do! assertExpected fileName messages
         }
@@ -53,7 +53,7 @@ module VirtualCallAnalyzerTests =
             let! messages =
                 File.ReadAllText fileName
                 |> getContext projectOptions
-                |> VirtualCallAnalyzer.virtualCallAnalyzer
+                |> VirtualCallAnalyzer.virtualCallCliAnalyzer
 
             Assert.That (messages, Is.Empty)
         }


### PR DESCRIPTION
To make all the analyzers available in editors, such as VS Code, this PR adds the needed support.

An example:
![Screenshot 2024-01-04 134839](https://github.com/G-Research/fsharp-analyzers/assets/3221269/220733ad-67f2-4d4c-9225-9c86928d7755)
