### PR TITLE
Markdown link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ permissions:
   id-token: write
 
 jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
   ci:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,6 @@ permissions:
     id-token: write
 
 jobs:
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-
   nuget-pack:
     runs-on: ubuntu-latest
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ permissions:
     id-token: write
 
 jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
   nuget-pack:
     runs-on: ubuntu-latest
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # G-Research Fsharp Analyzers
 
-![GitHub Workflow Status (event)](https://img.shields.io/github/actions/workflow/status/G-Research/fsharp-analyzers/main.yml?branch=main&label=CI&style=flat-square)
+![GitHub Workflow Status (event)](https://img.shields.io/github/actions/workflow/status/G-Research/fsharp-analyzers/release.yml?branch=main&label=CI&style=flat-square)
 [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/G-Research.FSharp.Analyzers?style=flat-square)](https://www.nuget.org/packages/G-Research.FSharp.Analyzers/absoluteLatest)
 
 A curated set of [Ionide SDK analyzers](https://ionide.io/FSharp.Analyzers.SDK/) for F#.


### PR DESCRIPTION
This wouldn't actually have caught the problem in https://github.com/G-Research/fsharp-analyzers/pull/58 because of course shields.io isn't returning a 404 for a non-existent pipeline, but oh well. You may or may not want this PR; feel free to ignore/close.