### PR TITLE
Allow '_' and '-' in named placeholders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Removed the PartialAppAnalyzer. [#68](https://github.com/G-Research/fsharp-analyzers/issues/68)
 
+### Fixed
+* Fixed a false positive of LoggingTemplateMissingValuesAnalyzer. [#69](https://github.com/G-Research/fsharp-analyzers/issues/69)
+
 ## 0.8.0 - 2024-01-30
 
 ### Fixed

--- a/src/FSharp.Analyzers/LoggingTemplateMissingValuesAnalyzer.fs
+++ b/src/FSharp.Analyzers/LoggingTemplateMissingValuesAnalyzer.fs
@@ -34,7 +34,7 @@ let analyze (typedTree : FSharpImplementationFileContents) =
                 "Microsoft.Extensions.Logging.LoggerExtensions.LogWarning"
             ]
 
-    let pattern = @"(?<opening>{+)[a-zA-Z0-9]*(?<closing>}+)"
+    let pattern = @"(?<opening>{+)[a-zA-Z0-9_-]*(?<closing>}+)"
     let regex = Regex pattern
 
     let walker =

--- a/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unusual template names.fs
+++ b/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unusual template names.fs
@@ -1,0 +1,9 @@
+module M
+
+    open Microsoft.Extensions.Logging
+
+    let testlog () =
+        use factory = LoggerFactory.Create(fun b -> b.AddConsole() |> ignore)
+        let logger: ILogger = factory.CreateLogger("Program")
+
+        logger.Log(LogLevel.Information, "xxx {o-ne} yyy {t_wo}", 23, 42)


### PR DESCRIPTION
Fixes #69
Turns out, it wasn't about the exception arg but about the '_' char in the named placeholder.