### PR TITLE
Fix a false positive in LoggingTemplateMissingValuesAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.3 - 2024-02-16
+
+### Fixed
+* Fixed a false positive of LoggingTemplateMissingValuesAnalyzer. [#78](https://github.com/G-Research/fsharp-analyzers/issues/78)
+
 ## 0.9.2 - 2024-02-16
 
 ### Fixed

--- a/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unbalanced braces.fs
+++ b/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unbalanced braces.fs
@@ -1,0 +1,9 @@
+module M
+
+    open Microsoft.Extensions.Logging
+
+    let testlog () =
+        use factory = LoggerFactory.Create(fun b -> b.AddConsole() |> ignore)
+        let logger: ILogger = factory.CreateLogger("Program")
+
+        logger.LogDebug("Blah {xxx}} foo {yyy}", 23)

--- a/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unusual template names2.fs
+++ b/tests/FSharp.Analyzers.Tests/data/loggingtemplatemissingvalues/negative/No warnings for unusual template names2.fs
@@ -1,0 +1,11 @@
+module M
+
+    open Microsoft.Extensions.Logging
+
+    let testlog () =
+        use factory = LoggerFactory.Create(fun b -> b.AddConsole() |> ignore)
+        let logger: ILogger = factory.CreateLogger("Program")
+        let someString = "someString"
+        let someOtherString = "someOtherString"
+
+        logger.LogDebug("Blah {s_thing:l} foo {s_other_thing:l}", someString, someOtherString)


### PR DESCRIPTION
- Don't enforce any regex inside the braces
- Only care about balanced braces

fixes #78
