### PR TITLE
Ensure access path is from FSharp namespace in VirtualCallAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.1 - 2024-01-08
+
+### Fixed
+* VirtualCall analyzer suggests quickfix on Collections.Generic.List. [#86](https://github.com/G-Research/fsharp-analyzers/issues/86)
+
 ## 0.12.0 - 2024-11-20
 
 ### Changed

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.400",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   }

--- a/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
+++ b/src/FSharp.Analyzers/VirtualCallAnalyzer.fs
@@ -29,17 +29,27 @@ let (|CoerceToSeq|_|) (includeFromSet : bool) (expr : FSharpExpr) =
                     StringComparison.Ordinal
                 )
             then
-                e.Type.TypeDefinition.AbbreviatedType.TypeDefinition.LogicalName
-            else
-                e.Type.TypeDefinition.LogicalName
+                Some e.Type.TypeDefinition.AbbreviatedType.TypeDefinition.LogicalName
+            elif
+                (let accessPath = e.Type.TypeDefinition.AccessPath in
 
-        match coercedValueTypeName with
-        | "[]`1"
-        | "array`1" -> Some "Array"
-        | "list`1"
-        | "List`1" -> Some "List"
-        | "Set`1" when includeFromSet -> Some "Set"
-        | _ -> None
+                 accessPath = "Microsoft.FSharp.Collections"
+                 || accessPath = "Microsoft.FSharp.Core")
+            then
+                Some e.Type.TypeDefinition.LogicalName
+            else
+                None
+
+        coercedValueTypeName
+        |> Option.bind (fun coercedValueTypeName ->
+            match coercedValueTypeName with
+            | "[]`1"
+            | "array`1" -> Some "Array"
+            | "list`1"
+            | "List`1" -> Some "List"
+            | "Set`1" when includeFromSet -> Some "Set"
+            | _ -> None
+        )
     | _ -> None
 
 let seqFuncsWithEquivalentsInAllCollections =

--- a/tests/FSharp.Analyzers.Tests/Common.fs
+++ b/tests/FSharp.Analyzers.Tests/Common.fs
@@ -8,7 +8,7 @@ open NUnit.Framework
 open FSharp.Analyzers.SDK
 
 [<Literal>]
-let framework = "net7.0"
+let framework = "net8.0"
 
 let shouldUpdateBaseline () =
     Environment.GetEnvironmentVariable "TEST_UPDATE_BSL"

--- a/tests/FSharp.Analyzers.Tests/data/virtualcall/negative/SystemCollectionsGenericList.fs
+++ b/tests/FSharp.Analyzers.Tests/data/virtualcall/negative/SystemCollectionsGenericList.fs
@@ -1,0 +1,4 @@
+module C
+
+let list = System.Collections.Generic.List<int>()
+let h = Seq.head list


### PR DESCRIPTION
Fixes #86 in the way that the analyzer won't trigger.
I'm not quite sure if this case is problematic with the usage of `Seq.tryHead`, leading to a virtual call or not. Thing is I'm not quite sure what the code fix would be.
We could revisit this in a future PR maybe. For now I would no longer report it.

Thoughts @dawedawe @Smaug123?