### PR TITLE
Update FSharp.Analyzers.SDK to 0.30.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "fsharp-analyzers": {
-      "version": "0.29.0",
+      "version": "0.30.0",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.14.0 - 2025-04-01
+
+### Changed
+* Update FSharp.Analyzers.SDK to `0.30.0`. [#89](https://github.com/G-Research/fsharp-analyzers/pull/89)
+
 ## 0.13.0 - 2025-02-14
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- locking the version of F# Core as FCS does this anyway and in practise all will be using the same version -->
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.29.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.29.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.30.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.30.0]" />
     <PackageVersion Include="FSharp.Core" Version="[9.0.201]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.9.201]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />


### PR DESCRIPTION
I guess there's magic which parses the CHANGELOG to get the version correct; this PR is basically a clone of https://github.com/G-Research/fsharp-analyzers/pull/88 .