### PR TITLE
Extend the string analyzers to analyze uses of String.LastIndexOf in …

### DIFF
--- a/docs/analyzers/StringAnalyzer.md
+++ b/docs/analyzers/StringAnalyzer.md
@@ -12,6 +12,7 @@ There are multiple analyzers for various string comparison functions:
 - String.EndsWith Analyzer
 - String.StartsWith Analyzer
 - String.IndexOf Analyzer
+- String.LastIndexOf Analyzer
 
 ## Problem
 

--- a/src/FSharp.Analyzers/StringAnalyzer.fs
+++ b/src/FSharp.Analyzers/StringAnalyzer.fs
@@ -15,6 +15,9 @@ let StringStartsWithCode = "GRA-STRING-002"
 let StringIndexOfCode = "GRA-STRING-003"
 
 [<Literal>]
+let StringLastIndexOfCode : string = "GRA-STRING-004"
+
+[<Literal>]
 let HelpUri =
     "https://g-research.github.io/fsharp-analyzers/analyzers/StringAnalyzer.html"
 
@@ -159,3 +162,33 @@ let indexOfCliAnalyzer (ctx : CliContext) : Async<Message list> =
 [<EditorAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
 let indexOfEditorAnalyzer (ctx : EditorContext) : Async<Message list> =
     async { return ctx.TypedTree |> Option.map indexOfAnalyze |> Option.defaultValue [] }
+
+let lastIndexOfAnalyze (typedTree : FSharpImplementationFileContents) =
+    invalidStringFunctionUseAnalyzer
+        "LastIndexOf"
+        StringLastIndexOfCode
+        "The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload."
+        Severity.Warning
+        typedTree
+        (fun args ->
+            match args with
+            | [ StringExpr ]
+            | [ StringExpr ; IntExpr ]
+            | [ StringExpr ; IntExpr ; IntExpr ] -> true
+            | _ -> false
+        )
+
+[<Literal>]
+let StringLastIndexOfName = "String.LastIndexOf Analyzer"
+
+[<Literal>]
+let StringLastIndexOfShortDescription =
+    "Verifies the correct usage of System.String.LastIndexOf"
+
+[<CliAnalyzer(StringLastIndexOfName, StringLastIndexOfShortDescription, HelpUri)>]
+let lastIndexOfCliAnalyzer (ctx : CliContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map lastIndexOfAnalyze |> Option.defaultValue [] }
+
+[<EditorAnalyzer(StringLastIndexOfName, StringLastIndexOfShortDescription, HelpUri)>]
+let lastIndexOfEditorAnalyzer (ctx : EditorContext) : Async<Message list> =
+    async { return ctx.TypedTree |> Option.map lastIndexOfAnalyze |> Option.defaultValue [] }

--- a/src/FSharp.Analyzers/StringAnalyzer.fsi
+++ b/src/FSharp.Analyzers/StringAnalyzer.fsi
@@ -49,3 +49,18 @@ val indexOfCliAnalyzer : ctx : CliContext -> Async<Message list>
 
 [<EditorAnalyzer(StringIndexOfName, StringIndexOfShortDescription, HelpUri)>]
 val indexOfEditorAnalyzer : ctx : EditorContext -> Async<Message list>
+
+[<Literal>]
+val StringLastIndexOfCode : string = "GRA-STRING-004"
+
+[<Literal>]
+val StringLastIndexOfName : string = "String.LastIndexOf Analyzer"
+
+[<Literal>]
+val StringLastIndexOfShortDescription : string = "Verifies the correct usage of System.String.LastIndexOf"
+
+[<CliAnalyzer(StringLastIndexOfName, StringLastIndexOfShortDescription, HelpUri)>]
+val lastIndexOfCliAnalyzer : ctx : CliContext -> Async<Message list>
+
+[<EditorAnalyzer(StringLastIndexOfName, StringLastIndexOfShortDescription, HelpUri)>]
+val lastIndexOfEditorAnalyzer : ctx : EditorContext -> Async<Message list>

--- a/tests/FSharp.Analyzers.Tests/StringAnalyzerTests.fs
+++ b/tests/FSharp.Analyzers.Tests/StringAnalyzerTests.fs
@@ -21,7 +21,7 @@ type TestCases() =
 
     interface IEnumerable with
         member _.GetEnumerator () : IEnumerator =
-            [| "endswith" ; "indexof" ; "startswith" |]
+            [| "endswith" ; "indexof" ; "startswith" ; "lastindexof" |]
             |> Seq.collect (fun subFolder ->
                 let folder = Path.Combine (dataFolder, "string", subFolder)
                 Directory.EnumerateFiles (folder, "*.fs")
@@ -36,6 +36,7 @@ let findStringAnalyzerFor (fileName : string) =
         | "endswith" -> StringAnalyzer.endsWithCliAnalyzer
         | "startswith" -> StringAnalyzer.startsWithCliAnalyzer
         | "indexof" -> StringAnalyzer.indexOfCliAnalyzer
+        | "lastindexof" -> StringAnalyzer.lastIndexOfCliAnalyzer
         | unknown -> failwithf $"Unknown subfolder \"%s{unknown}\", please configure analyzer"
 
 [<TestCaseSource(typeof<TestCases>)>]
@@ -55,7 +56,7 @@ type NegativeTestCases() =
 
     interface IEnumerable with
         member _.GetEnumerator () : IEnumerator =
-            [| "endswith" ; "indexof" ; "startswith" |]
+            [| "endswith" ; "indexof" ; "startswith" ; "lastindexof" |]
             |> Seq.collect (fun subFolder ->
                 let folder = Path.Combine (dataFolder, "string", subFolder, "negative")
                 Directory.EnumerateFiles (folder, "*.fs")

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - Single Argument.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - Single Argument.fs
@@ -1,0 +1,3 @@
+module M
+
+"foo".LastIndexOf("p")

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - Single Argument.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - Single Argument.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (3,0 - 3,22) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int Int.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int Int.fs
@@ -1,0 +1,3 @@
+module M
+
+"foo".LastIndexOf("p", 0 ,1)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int Int.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int Int.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (3,0 - 3,28) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int.fs
@@ -1,0 +1,3 @@
+module M
+
+"foo".LastIndexOf("p", 0)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Constant String - String Int.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (3,0 - 3,25) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Function call - Single Argument.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Function call - Single Argument.fs
@@ -1,0 +1,4 @@
+module M
+
+let f () = "f"
+"g".LastIndexOf(f())

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Function call - Single Argument.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Function call - Single Argument.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (4,0 - 4,20) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Prefixed Value - Single Argument.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Prefixed Value - Single Argument.fs
@@ -1,0 +1,6 @@
+module M
+
+module A =
+    let b = "b"
+
+A.b.LastIndexOf("b")

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Prefixed Value - Single Argument.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Prefixed Value - Single Argument.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (6,0 - 6,20) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Value - Single Argument.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Value - Single Argument.fs
@@ -1,0 +1,4 @@
+module M
+
+let a = "a"
+a.LastIndexOf("a")

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Value - Single Argument.fs.expected
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/Value - Single Argument.fs.expected
@@ -1,0 +1,1 @@
+GRA-STRING-004 | Warning | (4,0 - 4,18) | The usage of String.LastIndexOf with a single string argument is discouraged. Signal your intention explicitly by calling an overload. | []

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char Int32 Int32.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char Int32 Int32.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf('f',0,1)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char Int32.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char Int32.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf('f',0)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/Char.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf('f')

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String Int32 Int32 StringComparison.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String Int32 Int32 StringComparison.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf("f",0,1,StringComparison.InvariantCulture)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String Int32 StringComparison.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String Int32 StringComparison.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf("f",0,StringComparison.InvariantCulture)

--- a/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String StringComparison.fs
+++ b/tests/FSharp.Analyzers.Tests/data/string/lastindexof/negative/String StringComparison.fs
@@ -1,0 +1,4 @@
+module M
+
+open System
+"foo".LastIndexOf("f",StringComparison.InvariantCulture)


### PR DESCRIPTION
…the same way it does for String.IndexOf

This is largely copy/pasted from the IndexOf analyzer, with just a few changes to the function names.

refs https://github.com/G-Research/fsharp-analyzers/issues/21#issuecomment-3012652165, where it brings a bit more parity with the simlar analyzers for C#.