### PR TITLE
Factor out comment-searching code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.0 - 2025-08-27
+
+### Changed
+* The magic string for the DisposedBeforeAsyncRunAnalyzer has changed: it is now "disposed before returned workflow runs". [#94](https://github.com/G-Research/fsharp-analyzers/pull/94)
+
 ## 0.17.0 - 2025-07-12
 
 ### Changed

--- a/docs/analyzers/DisposedBeforeAsyncRunAnalyzer.md
+++ b/docs/analyzers/DisposedBeforeAsyncRunAnalyzer.md
@@ -31,10 +31,10 @@ let f () =
     }
 ```
 
-If the `use` before the `async` is really your intent, you can disable the warning with a line comment on top of the `use` statement containing `disposed before returned async runs` or `disposed before returned task runs`.
+If the `use` before the `async` is really your intent, you can disable the warning with a line comment on top of the `use` statement containing `disposed before returned workflow runs`.
 ```fsharp
 let f () =
-    // Note: disposed before returned async runs
+    // Note: disposed before returned workflow runs
     use t = new DisposableThing()
     async {
         return "hi"

--- a/src/FSharp.Analyzers/Comments.fs
+++ b/src/FSharp.Analyzers/Comments.fs
@@ -1,0 +1,28 @@
+module FSharp.Analyzers.Comments
+
+open System
+open FSharp.Compiler.SyntaxTrivia
+open FSharp.Compiler.Text
+
+/// A standard pattern within an analyzer is to look for a specific comment preceding a problematic line,
+/// indicating "suppress the analyzer on this line".
+/// This function performs that common check.
+let isSwitchedOffPerComment
+    (magicComment : string)
+    (comments : CommentTrivia list)
+    (sourceText : ISourceText)
+    (analyzerTriggeredOn : Range)
+    : bool
+    =
+    comments
+    |> List.exists (fun c ->
+        match c with
+        | CommentTrivia.LineComment r ->
+            if r.StartLine <> analyzerTriggeredOn.StartLine - 1 then
+                false
+            else
+                let lineOfComment = sourceText.GetLineString (r.StartLine - 1) // 0-based
+
+                lineOfComment.Contains (magicComment, StringComparison.OrdinalIgnoreCase)
+        | _ -> false
+    )

--- a/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
+++ b/src/FSharp.Analyzers/FSharp.Analyzers.fsproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Util.fs" />
+    <Compile Include="Comments.fs" />
     <Compile Include="StringAnalyzer.fsi" />
     <Compile Include="StringAnalyzer.fs" />
     <Compile Include="JsonSerializerOptionsAnalyzer.fs" />

--- a/tests/FSharp.Analyzers.Tests/data/disposedBeforeAsyncRun/negative/CommentOnUseBeforeAsync.fs
+++ b/tests/FSharp.Analyzers.Tests/data/disposedBeforeAsyncRun/negative/CommentOnUseBeforeAsync.fs
@@ -7,7 +7,7 @@ type DisposableThing () =
         member _.Dispose() = ()
 
 let asyncReturningFunc () =
-    // Note: disposed before returned async runs
+    // Note: disposed before returned workflow runs
     use t = new DisposableThing()
     async {
         return "hi"

--- a/tests/FSharp.Analyzers.Tests/data/disposedBeforeAsyncRun/negative/CommentOnUseBeforeTask.fs
+++ b/tests/FSharp.Analyzers.Tests/data/disposedBeforeAsyncRun/negative/CommentOnUseBeforeTask.fs
@@ -7,7 +7,7 @@ type DisposableThing () =
         member _.Dispose() = ()
 
 let taskReturningFunc () =
-    // Note: disposed before returned task runs
+    // Note: disposed before returned workflow runs
     use t = new DisposableThing()
     task {
         return "hi"


### PR DESCRIPTION
I have written another analyzer which also wants this functionality, so here's a standalone PR that factors it out.

This change is breaking, but hopefully in a fairly obvious way (the changed magic string, which makes the factored function simpler by only having to consider one string).