### PR TITLE
GROSS-1358: SHA-pin GitHub Actions and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       - name: Build
         run: dotnet fsi build.fsx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,20 @@ jobs:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       - name: Build
         run: dotnet fsi build.fsx
       - name: Pack
         run: dotnet pack src/FSharp.Analyzers/FSharp.Analyzers.fsproj --configuration Release --output artifacts
       - name: Upload NuGet artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nuget-package
           path: artifacts/G-Research.FSharp.Analyzers.*.nupkg
       - name: Upload documentation
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
             path: ./output
 
@@ -39,7 +39,7 @@ jobs:
     environment: release
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: nuget-package
       - name: Publish to NuGet
@@ -51,4 +51,4 @@ jobs:
       steps:
           - name: Deploy to GitHub Pages
             id: deployment
-            uses: actions/deploy-pages@v4
+            uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments) and enable Dependabot for the `github-actions` ecosystem.

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` ref can be silently rewritten by the upstream maintainer (or a compromised account) and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing `# <version>` comment keeps the pin human-readable. Dependabot is enabled so the pins are kept up to date automatically instead of going stale.

## Notes

- Existing major versions were pinned to their current SHA — this is a pin, not a version bump. Future upgrades are left to Dependabot.
- No functional change to CI behaviour.