### PR TITLE
Update release pipeline for trusted publishing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-package
+      - name: Obtain NuGet key
+        id: login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish to NuGet
-        run: dotnet nuget push "G-Research.FSharp.Analyzers.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "G-Research.FSharp.Analyzers.*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   deploy:
       runs-on: ubuntu-latest


### PR DESCRIPTION
Hey @pavlovic-ivan, could you set up trusted publishing for the `G-Research.FSharp.Analyzers` NuGet package:

*Trusted Publishing* settings:

| Field                | Value                                    |
| -------------------- | ---------------------------------------- |
| Repository owner     | `G-Research`                             |
| Repository           | `fsharp-analyzers`                       |
| Workflow file        | `release.yml`                            |
| Environment          | `release`                                |
| Package owner        | the account that owns the package listing |

The `release` environment already exists on the `nuget-publish` job, so the environment
field must be filled in and must match exactly. Leaving it blank would let any workflow
run in this repository publish, which is precisely the exposure we are removing.

After that we need `NUGET_USER` secret to the repo.
Is that a yaml config change or something manual?

And as clean-up we can remove `NUGET_API_KEY`.